### PR TITLE
Settings serialization - menu

### DIFF
--- a/configs/base/keys.cfg
+++ b/configs/base/keys.cfg
@@ -1,195 +1,109 @@
- /* keybindings */
-
-binds =
-(
+binds = ( 
   {
     action = "action_look_x";
-    inputs =
-    [
-      "input_mouse_x"
-    ];
-  },
-  {
-    action = "action_look_y";
-    inputs =
-    [
-      "input_mouse_y"
-    ];
-  },
-  {
-    action = "action_left";
-    inputs =
-    [
-      "input_a"
-    ];
-  },
-  {
-    action = "action_right";
-    inputs =
-    [
-      "input_d"
-    ];
-  },
-  {
-    action = "action_forward";
-    inputs =
-    [
-      "input_w"
-    ];
-  },
-  {
-    action = "action_back";
-    inputs =
-    [
-      "input_s"
-    ];
-  },
-  {
-    action = "action_jump";
-    inputs =
-    [
-      "input_space"
-    ];
-  },
-  {
-    action = "action_use";
-    inputs =
-    [
-      "input_e"
-    ];
-  },
+    inputs = [ "input_mouse_x" ];
+  }, 
   {
     action = "action_menu";
-    inputs =
-    [
-      "input_escape"
-    ];
-  },
+    inputs = [ "input_escape" ];
+  }, 
+  {
+    action = "action_look_y";
+    inputs = [ "input_mouse_y" ];
+  }, 
+  {
+    action = "action_left";
+    inputs = [ "input_a" ];
+  }, 
+  {
+    action = "action_right";
+    inputs = [ "input_d" ];
+  }, 
+  {
+    action = "action_forward";
+    inputs = [ "input_w" ];
+  }, 
+  {
+    action = "action_back";
+    inputs = [ "input_s" ];
+  }, 
+  {
+    action = "action_jump";
+    inputs = [ "input_space" ];
+  }, 
+  {
+    action = "action_use";
+    inputs = [ "input_e" ];
+  }, 
   {
     action = "action_menu_confirm";
-    inputs =
-    [
-      "input_return"
-    ];
-  },
+    inputs = [ "input_return" ];
+  }, 
   {
     action = "action_menu_up";
-    inputs =
-    [
-      "input_up"
-    ];
-  },
+    inputs = [ "input_up" ];
+  }, 
   {
     action = "action_menu_down";
-    inputs =
-    [
-      "input_down"
-    ];
-  },
+    inputs = [ "input_down" ];
+  }, 
   {
     action = "action_reset";
-    inputs =
-    [
-      "input_r"
-    ];
-  },
+    inputs = [ "input_r" ];
+  }, 
   {
     action = "action_crouch";
-    inputs =
-    [
-      "input_lctrl",
-      "input_c"
-    ];
-  },
+    inputs = [ "input_lctrl", "input_c" ];
+  }, 
   {
     action = "action_gravity";
-    inputs =
-    [
-      "input_g"
-    ];
-  },
+    inputs = [ "input_g" ];
+  }, 
   {
     action = "action_use_tool";
-    inputs =
-    [
-      "input_mouse_left"
-    ];
-  },
+    inputs = [ "input_mouse_left" ];
+  }, 
   {
     action = "action_tool_next";
-    inputs =
-    [
-      "input_mouse_wheelup"
-    ];
-  },
+    inputs = [ "input_mouse_wheelup" ];
+  }, 
   {
     action = "action_tool_prev";
-    inputs =
-    [
-      "input_mouse_wheeldown"
-    ];
-  },
+    inputs = [ "input_mouse_wheeldown" ];
+  }, 
   {
     action = "action_slot1";
-    inputs =
-    [
-      "input_1"
-    ];
-  },
+    inputs = [ "input_1" ];
+  }, 
   {
     action = "action_slot2";
-    inputs =
-    [
-      "input_2"
-    ];
-  },
+    inputs = [ "input_2" ];
+  }, 
   {
     action = "action_slot3";
-    inputs =
-    [
-      "input_3"
-    ];
-  },
+    inputs = [ "input_3" ];
+  }, 
   {
     action = "action_slot4";
-    inputs =
-    [
-      "input_4"
-    ];
-  },
+    inputs = [ "input_4" ];
+  }, 
   {
     action = "action_slot5";
-    inputs =
-    [
-      "input_5"
-    ];
-  },
+    inputs = [ "input_5" ];
+  }, 
   {
     action = "action_slot6";
-    inputs =
-    [
-      "input_6"
-    ];
-  },
+    inputs = [ "input_6" ];
+  }, 
   {
     action = "action_slot7";
-    inputs =
-    [
-      "input_7"
-    ];
-  },
+    inputs = [ "input_7" ];
+  }, 
   {
     action = "action_slot8";
-    inputs =
-    [
-      "input_8"
-    ];
-  },
+    inputs = [ "input_8" ];
+  }, 
   {
     action = "action_slot9";
-    inputs =
-    [
-      "input_9"
-    ];
-  }
-);
+    inputs = [ "input_9" ];
+  } );

--- a/main.cc
+++ b/main.cc
@@ -1102,6 +1102,10 @@ struct menu_settings_state : game_state
             // ^^ Not real keen on requiring these to be static
 
         items.push_back(
+            menu_item("Save Settings", "",
+            []{ save_settings(game_settings); }));
+
+        items.push_back(
             menu_item("Back", "",
             []{ set_game_state(create_menu_state()); }));
     }

--- a/main.cc
+++ b/main.cc
@@ -45,7 +45,7 @@ bool exit_requested = false;
 
 auto hfov = DEG2RAD(90.f);
 
-settings en_settings;
+en_settings game_settings;
 
 struct wnd {
     SDL_Window *ptr;
@@ -413,9 +413,9 @@ init()
     if( ! ship )
         errx(1, "Ship_space::mock_ship_space failed\n");
 
-    en_settings = load_settings(en_config_base);
-    settings user_settings = load_settings(en_config_user);
-    en_settings.merge_with(user_settings);
+    game_settings = load_settings(en_config_base);
+    en_settings user_settings = load_settings(en_config_user);
+    game_settings.merge_with(user_settings);
 
     pl.angle = 0;
     pl.elev = 0;
@@ -817,7 +817,7 @@ update()
 
 
 action const* get_input(en_action a) {
-    return &en_settings.bindings.bindings[a];
+    return &game_settings.bindings.bindings[a];
 }
 
 
@@ -963,10 +963,10 @@ struct play_state : game_state {
 
         /* persistent */
 
-        float mouse_invert = en_settings.input.mouse_invert;
+        float mouse_invert = game_settings.input.mouse_invert;
 
-        pl.angle += en_settings.input.mouse_x_sensitivity * look_x;
-        pl.elev += en_settings.input.mouse_y_sensitivity * mouse_invert * look_y;
+        pl.angle += game_settings.input.mouse_x_sensitivity * look_x;
+        pl.elev += game_settings.input.mouse_y_sensitivity * mouse_invert * look_y;
 
         if (pl.elev < -MOUSE_Y_LIMIT)
             pl.elev = -MOUSE_Y_LIMIT;
@@ -1108,7 +1108,7 @@ struct menu_settings_state : game_state
     
     static void toggle_mouse_invert() {
     // ^^ Not real keen on requiring these to be static
-        en_settings.input.mouse_invert *= -1;
+        game_settings.input.mouse_invert *= -1;
     }
     
     void update() override {
@@ -1123,7 +1123,7 @@ struct menu_settings_state : game_state
 
     void rebuild_ui() override {
         menu_item *invert_item = &items.at(mouse_invert_mi);
-        std::get<1>(*invert_item) = en_settings.input.mouse_invert > 0 ? off_text : on_text;
+        std::get<1>(*invert_item) = game_settings.input.mouse_invert > 0 ? off_text : on_text;
 
         float w = 0;
         float h = 0;
@@ -1180,7 +1180,7 @@ game_state *game_state::create_menu_settings_state() { return new menu_settings_
 void
 handle_input()
 {
-    set_inputs(keys, mouse_buttons, mouse_axes, en_settings.bindings.bindings);
+    set_inputs(keys, mouse_buttons, mouse_axes, game_settings.bindings.bindings);
     state->handle_input();
 }
 

--- a/nightmare.sln.DotSettings
+++ b/nightmare.sln.DotSettings
@@ -1,0 +1,23 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=DECLSPEC_005FPROPERTY/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=ENUM/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=ENUMERATOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=GETTER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=GLOBAL_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=GLOBAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=LOCAL_005FTYPEDEF/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=LOCAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=NAMESPACE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=PARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=SETTER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="set_" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=STRUCT/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=STRUCT_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="_" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=STRUCT_005FMETHODS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=TEMPLATE_005FPARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=TYPEDEF/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=UNION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/UserRules/=UNION_005FMEMBER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CppFormatting/INVOCABLE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CppFormatting/NAMESPACE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CppFormatting/OTHER_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CppFormatting/TYPE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String></wpf:ResourceDictionary>

--- a/src/config.cc
+++ b/src/config.cc
@@ -48,15 +48,15 @@ const char* get_keys_config_path(en_config_type config_type) {
 }
 
 void
-settings::merge_with(settings other) {
-    this->input.merge_with(other.input);
-    this->video.merge_with(other.video);
-    this->bindings.merge_with(other.bindings);
+en_settings::merge_with(en_settings other) {
+    input.merge_with(other.input);
+    video.merge_with(other.video);
+    bindings.merge_with(other.bindings);
 }
 
-settings
+en_settings
 load_settings(en_config_type config_type) {
-    settings loaded_settings;
+    en_settings loaded_settings;
 
     loaded_settings.input    = load_input_settings(config_type);
     loaded_settings.bindings = load_binding_settings(config_type);

--- a/src/config.cc
+++ b/src/config.cc
@@ -86,7 +86,7 @@ load_binding_settings(en_config_type config_type) {
 
     binds_config_setting = config_lookup(&cfg, "binds");
 
-    if (binds_config_setting != NULL) {
+    if (binds_config_setting != nullptr) {
         /* http://www.hyperrealm.com/libconfig/libconfig_manual.html
         * states
         *  > int config_setting_length (const config_setting_t * setting)
@@ -102,8 +102,8 @@ load_binding_settings(en_config_type config_type) {
             config_setting_t *bind, *inputs;
             bind = config_setting_get_elem(binds_config_setting, i);
 
-            const char **inputs_names = NULL;
-            const char *action_name = NULL;
+            const char **inputs_names = nullptr;
+            const char *action_name = nullptr;
             unsigned int inputs_count = 0;
 
             config_setting_lookup_string(bind, "action", &action_name);
@@ -172,7 +172,7 @@ load_input_settings(en_config_type config_type) {
 
     input_config_setting = config_lookup(&cfg, "input");
 
-    if (input_config_setting != NULL) {
+    if (input_config_setting != nullptr) {
         double mouse_invert        = 0.0;
         double mouse_x_sensitivity = 0.0;
         double mouse_y_sensitivity = 0.0;

--- a/src/config.h
+++ b/src/config.h
@@ -10,12 +10,14 @@ enum en_config_type {
     en_config_user,
 };
 
+void save_settings(en_settings);
+void save_binding_settings(binding_settings);
+void save_video_settings(video_settings);
+void save_input_settings(input_settings);
 
 en_settings load_settings(en_config_type);
 input_settings load_input_settings(en_config_type);
-
 binding_settings load_binding_settings(en_config_type);
-
 video_settings load_video_settings(en_config_type);
 
 en_settings merge_settings(en_settings, en_settings);

--- a/src/config.h
+++ b/src/config.h
@@ -10,12 +10,12 @@ enum en_config_type {
     en_config_user,
 };
 
-settings load_settings(en_config_type);
 
+en_settings load_settings(en_config_type);
 input_settings load_input_settings(en_config_type);
 
 binding_settings load_binding_settings(en_config_type);
 
 video_settings load_video_settings(en_config_type);
 
-settings merge_settings(settings, settings);
+en_settings merge_settings(en_settings, en_settings);

--- a/src/input.cc
+++ b/src/input.cc
@@ -85,8 +85,6 @@ std::unordered_map<en_action, action, std::hash<int>> &actions) {
         auto binds = &action->binds;
 
         for (auto &input : binds->inputs) {
-            input_type type = input_type_invalid;
-
             switch (get_input_type(input))
             {
             default:

--- a/src/input.cc
+++ b/src/input.cc
@@ -31,7 +31,7 @@ get_input_type(en_input input) {
 */
 en_action
 lookup_action(const char *lookup) {
-    for (const action_lookup_t *input = action_lookup_table; input->name != NULL; ++input) {
+    for (const action_lookup_t *input = action_lookup_table; input->name != nullptr; ++input) {
         if (strcmp(input->name, lookup) == 0) {
             return input->action;
         }
@@ -42,17 +42,17 @@ lookup_action(const char *lookup) {
 /* This is probably only useful for populating config files */
 const char*
 lookup_input_action(en_action lookup) {
-    for (const action_lookup_t *input = action_lookup_table; input->name != NULL; ++input) {
+    for (const action_lookup_t *input = action_lookup_table; input->name != nullptr; ++input) {
         if (input->action == lookup) {
             return input->name;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 en_input
 lookup_input(const char *lookup) {
-    for (const input_lookup_t *input = input_lookup_table; input->name != NULL; ++input) {
+    for (const input_lookup_t *input = input_lookup_table; input->name != nullptr; ++input) {
         if (strcmp(input->name, lookup) == 0) {
             return input->action;
         }
@@ -63,12 +63,12 @@ lookup_input(const char *lookup) {
 /* This is probably only useful for populating config files */
 const char*
 lookup_input(en_input lookup) {
-    for (const input_lookup_t *input = input_lookup_table; input->name != NULL; ++input) {
+    for (const input_lookup_t *input = input_lookup_table; input->name != nullptr; ++input) {
         if (input->action == lookup) {
             return input->name;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 void

--- a/src/input.h
+++ b/src/input.h
@@ -398,7 +398,7 @@ struct action {
     bool just_active = false;   /* did action go active this frame */
     bool just_inactive = false; /* did action go inactive this frame */
     Uint32 last_active = 0;     /* time of last activation */
-    Uint32 current_active = 0;  /* duration of current activation */
+    Uint32 current_active = 0;  /* duration of current activation (milliseconds) */
 
     action()
     {

--- a/src/settings.h
+++ b/src/settings.h
@@ -13,7 +13,15 @@
 #define INVALID_SETTINGS_INT INT_MAX
 #define INVALID_SETTINGS_FLOAT FLT_MAX
 
-struct video_settings {
+template <typename T>
+struct settings {
+    virtual ~settings() {}
+
+    virtual void merge_with(T) = 0;
+    virtual T get_delta(T) = 0;
+};
+
+struct video_settings : settings<video_settings> {
     /* render xres */           /* render framebuffer to this size (usually window size) */
     /* render yres */           /* render framebuffer to this size (usually window size) */
     /* framebuffer xres */      /* for super/sub sampling? */
@@ -23,27 +31,31 @@ struct video_settings {
     /* anisotropy */            /* less eye bleed */
     /* antialiasing */          /* SMAA, CSAAS, FXAA, ETCAA*/
 
-    void merge_with(video_settings);
+    void merge_with(video_settings) override;
+    video_settings get_delta(video_settings) override;
 };
 
-struct input_settings {
+struct input_settings : settings<input_settings> {
     float mouse_invert        = INVALID_SETTINGS_FLOAT;
     float mouse_x_sensitivity = INVALID_SETTINGS_FLOAT;
     float mouse_y_sensitivity = INVALID_SETTINGS_FLOAT;
 
-    void merge_with(input_settings);
+    void merge_with(input_settings) override;
+    input_settings get_delta(input_settings) override;
 };
 
-struct binding_settings {
+struct binding_settings : settings<binding_settings> {
     std::unordered_map<en_action, action, std::hash<int>> bindings;
 
-    void merge_with(binding_settings);
+    void merge_with(binding_settings) override;
+    binding_settings get_delta(binding_settings) override;
 };
 
-struct settings {
+struct en_settings : settings<en_settings> {
     video_settings video;
     input_settings input;
     binding_settings bindings;
 
-    void merge_with(settings);
+    void merge_with(en_settings) override;
+    en_settings get_delta(en_settings) override;
 };


### PR DESCRIPTION
This adds the ability to serialize all current settings to user config directory.
Settings menu added with ability to toggle mouse invert (and then save said change!)

Can be tested by running with/modifying the files found the following in the configs/user directory:
https://gist.github.com/RobotCaleb/8011096a45d3056d6e42
