### PR TITLE
shaders: use mix() instead of open-coded lerp

### DIFF
--- a/shaders/simple.frag
+++ b/shaders/simple.frag
@@ -21,7 +21,10 @@ void main(void)
     vec3 light_lookup_pos = (ws_pos + light_step * ws_norm);
     /* quantize for stylized look */
     light_lookup_pos = round(light_lookup_pos * light_pos_quantize_factor) / light_pos_quantize_factor;
-    float light = ambientAmount + (1 - ambientAmount) * texture(s_light_field, light_lookup_pos / textureSize(s_light_field, 0)).x;
+    float light = mix(
+		texture(s_light_field, light_lookup_pos / textureSize(s_light_field, 0)).x,
+		1.0,
+		ambientAmount);
 
 	color = texture(s_albedo, texcoord) * light;
 


### PR DESCRIPTION
Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>