### PR TITLE
Implement atmo pressure on top of ship topology

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -206,6 +206,9 @@ struct entity
         printf("player using the %s at %d %d %d\n",
                type->name, x, y, z);
     }
+
+    void tick() {
+    }
 };
 
 
@@ -790,6 +793,13 @@ update()
 
     /* TODO: only do this when needed */
     ship->rebuild_topology();
+
+    /* allow the entities to tick */
+    for (auto ch : ship->chunks) {
+        for (auto e : ch.second->entities) {
+            e->tick();
+        }
+    }
 
     world_textures->bind(0);
 

--- a/main.cc
+++ b/main.cc
@@ -210,6 +210,24 @@ struct entity
     }
 
     void tick() {
+        if (type->add_air_amount <= 0) {
+            /* TODO: components */
+            return;
+        }
+
+        /* topo node containing the ent */
+        topo_info *t = topo_find(ship->get_topo_info(x, y, z));
+        /* zoneinfo attached */
+        zone_info *z = ship->get_zone_info(t);
+        if (!z) {
+            /* if there wasnt a zone, make one. */
+            z = ship->zones[t] = new zone_info(0);
+        }
+
+        /* add some air if we can, up to our pressure limit */
+        float max_air = type->max_air_pressure * t->size;
+        if (z->air_amount < max_air)
+            z->air_amount = std::min(max_air, z->air_amount + type->add_air_amount);
     }
 };
 
@@ -412,18 +430,24 @@ init()
     set_mesh_material(entity_types[0].sw, 3);
     entity_types[0].hw = upload_mesh(entity_types[0].sw);
     entity_types[0].name = "Frobnicator";
+    entity_types[0].add_air_amount = 0.1f;
+    entity_types[0].max_air_pressure = 1.0f;
     build_static_physics_mesh(entity_types[0].sw, &entity_types[0].phys_mesh, &entity_types[0].phys_shape);
 
     entity_types[1].sw = load_mesh("mesh/panel_4x4.obj");
     set_mesh_material(entity_types[1].sw, 7);
     entity_types[1].hw = upload_mesh(entity_types[1].sw);
     entity_types[1].name = "Display Panel (4x4)";
+    entity_types[1].add_air_amount = 0.0f;
+    entity_types[1].max_air_pressure = 0.0f;
     build_static_physics_mesh(entity_types[1].sw, &entity_types[1].phys_mesh, &entity_types[1].phys_shape);
 
     entity_types[2].sw = load_mesh("mesh/panel_4x4.obj");
     set_mesh_material(entity_types[2].sw, 8);
     entity_types[2].hw = upload_mesh(entity_types[2].sw);
     entity_types[2].name = "Light (4x4)";
+    entity_types[2].add_air_amount = 0.0f;
+    entity_types[2].max_air_pressure = 0.0f;
     build_static_physics_mesh(entity_types[2].sw, &entity_types[2].phys_mesh, &entity_types[2].phys_shape);
 
     simple_shader = load_shader("shaders/simple.vert", "shaders/simple.frag");

--- a/main.cc
+++ b/main.cc
@@ -172,6 +172,8 @@ struct entity_type
     char const *name;
     btTriangleMesh *phys_mesh;
     btCollisionShape *phys_shape;
+    float add_air_amount;
+    float max_air_pressure;
 };
 
 
@@ -945,11 +947,14 @@ struct play_state : game_state {
 
             topo_info *t = topo_find(ship->get_topo_info(plx, ply, plz));
             topo_info *outside = topo_find(&ship->outside_topo_info);
+            zone_info *z = ship->get_zone_info(t);
+            float pressure = z ? (z->air_amount / t->size) : 0.0f;
+
             if (t != outside) {
-                sprintf(buf2, "[INSIDE %p %d]", t, t->size);
+                sprintf(buf2, "[INSIDE %p %d %.1f atmo]", t, t->size, pressure);
             }
             else {
-                sprintf(buf2, "[OUTSIDE %p %d]", t, t->size);
+                sprintf(buf2, "[OUTSIDE %p %d %.1f atmo]", t, t->size, pressure);
             }
 
             w = 0; h = 0;

--- a/main.cc
+++ b/main.cc
@@ -793,6 +793,16 @@ update()
     /* rebuild lighting if needed */
     update_lightfield();
 
+    /* remove any air that someone managed to get into the outside */
+    {
+        topo_info *t = topo_find(&ship->outside_topo_info);
+        zone_info *z = ship->get_zone_info(t);
+        if (z) {
+            /* try as hard as you like, you cannot fill space with your air system */
+            z->air_amount = 0;
+        }
+    }
+
     /* allow the entities to tick */
     for (auto ch : ship->chunks) {
         for (auto e : ch.second->entities) {

--- a/main.cc
+++ b/main.cc
@@ -957,10 +957,11 @@ struct play_state : game_state {
             add_text_with_outline(buf2, -w/2, -100);
 
             w = 0; h = 0;
-            sprintf(buf2, "full: %d fast-unify: %d fast-nosplit: %d",
+            sprintf(buf2, "full: %d fast-unify: %d fast-nosplit: %d false-split: %d",
                     ship->num_full_rebuilds,
                     ship->num_fast_unifys,
-                    ship->num_fast_nosplits);
+                    ship->num_fast_nosplits,
+                    ship->num_false_splits);
             text->measure(buf2, &w, &h);
             add_text_with_outline(buf2, -w/2, -150);
         }

--- a/main.cc
+++ b/main.cc
@@ -791,9 +791,6 @@ update()
     /* rebuild lighting if needed */
     update_lightfield();
 
-    /* TODO: only do this when needed */
-    ship->rebuild_topology();
-
     /* allow the entities to tick */
     for (auto ch : ship->chunks) {
         for (auto e : ch.second->entities) {

--- a/src/ship_space.cc
+++ b/src/ship_space.cc
@@ -5,7 +5,8 @@
 
 /* create a ship space of x * y * z instantiated chunks */
 ship_space::ship_space(unsigned int xd, unsigned int yd, unsigned int zd)
-    : min_x(0), min_y(0), min_z(0), num_full_rebuilds(0), num_fast_unifys(0), num_fast_nosplits(0)
+    : min_x(0), min_y(0), min_z(0), num_full_rebuilds(0), num_fast_unifys(0), num_fast_nosplits(0),
+      num_false_splits(0)
 {
     unsigned int x = 0,
                  y = 0,
@@ -31,7 +32,7 @@ ship_space::ship_space(unsigned int xd, unsigned int yd, unsigned int zd)
 /* create an empty ship_space */
 ship_space::ship_space(void)
     : min_x(0), min_y(0), min_z(0), max_x(0), max_y(0), max_z(0),
-      num_full_rebuilds(0), num_fast_unifys(0), num_fast_nosplits(0)
+      num_full_rebuilds(0), num_fast_unifys(0), num_fast_nosplits(0), num_false_splits(0)
 {
 }
 
@@ -442,6 +443,15 @@ ship_space::update_topology_for_add_surface(int x, int y, int z, int px, int py,
 
     /* we do need to split */
     rebuild_topology();
+
+    topo_info *t1 = topo_find(get_topo_info(x, y, z));
+    topo_info *t2 = topo_find(get_topo_info(px, py, pz));
+    if (t1 == t2) {
+        /* we blew it. we didn't actually split the space, but we did
+         * all the work anyway. this is mostly interesting if you're
+         * tweaking exists_alt_path. */
+        num_false_splits++;
+    }
 }
 
 static glm::ivec3 dirs[] = {

--- a/src/ship_space.cc
+++ b/src/ship_space.cc
@@ -116,6 +116,16 @@ ship_space::get_topo_info(int block_x, int block_y, int block_z)
     return c->topo.get(wb_x, wb_y, wb_z);
 }
 
+zone_info *
+ship_space::get_zone_info(topo_info *t)
+{
+    auto it = zones.find(t);
+    if (it == zones.end())
+        return nullptr;
+
+    return it->second;
+}
+
 /* returns the chunk containing the block denotated by (x, y, z)
  * or null
  */

--- a/src/ship_space.h
+++ b/src/ship_space.h
@@ -101,7 +101,6 @@ struct ship_space {
     void rebuild_topology();
     void update_topology_for_remove_surface(int x, int y, int z, int px, int py, int pz, int face);
     void update_topology_for_add_surface(int x, int y, int z, int px, int py, int pz, int face);
-    bool topo_dirty;
 
     int num_full_rebuilds;
     int num_fast_unifys;

--- a/src/ship_space.h
+++ b/src/ship_space.h
@@ -102,9 +102,10 @@ struct ship_space {
     void update_topology_for_remove_surface(int x, int y, int z, int px, int py, int pz, int face);
     void update_topology_for_add_surface(int x, int y, int z, int px, int py, int pz, int face);
 
-    int num_full_rebuilds;
-    int num_fast_unifys;
-    int num_fast_nosplits;
+    int num_full_rebuilds;      /* number of full rebuilds (pretty slow) performed */
+    int num_fast_unifys;        /* number of incremental unify operations performed */
+    int num_fast_nosplits;      /* number of rebuilds avoided because we proved them spurious */
+    int num_false_splits;       /* number of useless rebuilds taken */
 };
 
 /* helper */

--- a/src/ship_space.h
+++ b/src/ship_space.h
@@ -25,6 +25,12 @@ struct raycast_info {
     struct block *block;
 };
 
+struct zone_info {
+    float air_amount;
+
+    zone_info(float air_amount) : air_amount(air_amount) {}
+};
+
 struct ship_space {
     /* the min and max chunk co-ords ship_space has seen for each axis
      * this is for iteration (min_x..max_x) (inclusive)
@@ -41,6 +47,7 @@ struct ship_space {
     void _maintain_bounds(int x_seen, int y_seen, int z_seen);
 
     std::unordered_map<glm::ivec3, chunk*, ivec3_hash> chunks;
+    std::unordered_map<topo_info *, zone_info *> zones;
 
     /* create a ship space of x * y * z instantiated chunks */
     ship_space(unsigned int xdim, unsigned int ydim, unsigned int zdim);
@@ -95,6 +102,8 @@ struct ship_space {
      * this will not instantiate or modify any other chunks
      */
     void ensure_chunk(int chunk_x, int chunk_y, int chunk_z);
+
+    zone_info *get_zone_info(topo_info *t);
 
     /* topo info for open vacuum, so we know what pressure to force to zero */
     topo_info outside_topo_info;

--- a/src/ship_space.h
+++ b/src/ship_space.h
@@ -104,6 +104,7 @@ struct ship_space {
     void ensure_chunk(int chunk_x, int chunk_y, int chunk_z);
 
     zone_info *get_zone_info(topo_info *t);
+    void insert_zone(topo_info *t, zone_info *z);
 
     /* topo info for open vacuum, so we know what pressure to force to zero */
     topo_info outside_topo_info;


### PR DESCRIPTION
This series tidies up the topology handling in ship_space and builds a workable atmosphere model on top of it.

The frobnicator can be added to the world to emit 0.1 mass unit of air per tick into its containing zone, up to a max pressure of 1.0 (we don't do gas temperature or other weird constants yet, so pressure=mass/volume).

Removing a surface between two spaces causes them to instantly equalize. Sealing off a space causes splitting of the zone, with mass distributed according to the volume ratio to maintain equal pressure.