### PR TITLE
mesh: Use less exotic vertex format, to avoid angering AMD

### DIFF
--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -97,10 +97,10 @@ upload_mesh(sw_mesh *mesh)
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(vertex), (GLvoid const *)offsetof(vertex, x));
 
     glEnableVertexAttribArray(1);
-    glVertexAttribIPointer(1, 1, GL_UNSIGNED_SHORT, sizeof(vertex), (GLvoid const *)offsetof(vertex, mat));
+    glVertexAttribIPointer(1, 1, GL_UNSIGNED_INT, sizeof(vertex), (GLvoid const *)offsetof(vertex, mat));
 
     glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 4, GL_INT_2_10_10_10_REV, GL_FALSE, sizeof(vertex), (GLvoid const *)offsetof(vertex, normal_packed));
+    glVertexAttribPointer(2, 4, GL_FLOAT, GL_FALSE, sizeof(vertex), (GLvoid const *)offsetof(vertex, nx));
 
     glGenBuffers(1, &ret->ibo);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ret->ibo);

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -12,16 +12,21 @@ struct hw_mesh {
 
 
 /* TODO: pack this a bit better */
+/* TODO: use packed normals on drivers that will accept them reliably. This
+ * provokes a crash on AMD/windows.
+ */
 struct vertex {
     float x, y, z;
-    uint32_t normal_packed;
-    uint16_t mat;
+    float nx, ny, nz;
+    //uint32_t normal_packed;
+    uint32_t mat;
 
     vertex() : x(0), y(0), z(0), mat(0) {}
 
     vertex(float x, float y, float z, float nx, float ny, float nz, int mat)
         : x(x), y(y), z(z),
-          normal_packed(glm::packSnorm3x10_1x2(glm::vec4(nx, ny, nz, 0))),
+          nx(nx), ny(ny), nz(nz),
+          //normal_packed(glm::packSnorm3x10_1x2(glm::vec4(nx, ny, nz, 0))),
           mat(mat)
     {
     }


### PR DESCRIPTION
Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>