### PR TITLE
main: Request at least 24 bits of depth

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1467,6 +1467,7 @@ main(int, char **)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 
     wnd.ptr = SDL_CreateWindow(APP_NAME,
                                SDL_WINDOWPOS_CENTERED,


### PR DESCRIPTION
Fixes missing sky on AMD, various z-fighting fails. Not noticed on i965
because we don't give a Z16 surface anyway -- it's slower than Z24X8 for
obscure hardware reasons.

Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>