### PR TITLE
textureset: Add support for old-style cubes

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -512,7 +512,7 @@ init()
     world_textures->load(7, "textures/display.png");
     world_textures->load(8, "textures/light.png");
 
-    skybox = new texture_set(GL_TEXTURE_CUBE_MAP_ARRAY, 2048, 6);
+    skybox = new texture_set(GL_TEXTURE_CUBE_MAP, 2048, 6);
     skybox->load(0, "textures/sky_right1.png");
     skybox->load(1, "textures/sky_left2.png");
     skybox->load(2, "textures/sky_top3.png");

--- a/shaders/sky.frag
+++ b/shaders/sky.frag
@@ -1,10 +1,9 @@
 #version 330 core
 // for sampler bindings.
 #extension GL_ARB_shading_language_420pack: require
-#extension GL_ARB_texture_cube_map_array: require
 
 
-layout(binding=0) uniform samplerCubeArray s_sky;
+layout(binding=0) uniform samplerCube s_sky;
 
 
 in vec3 view_dir;
@@ -15,7 +14,7 @@ layout(location=0) out vec4 color;
 
 void main(void)
 {
-    color = texture(s_sky, vec4(view_dir, 0));
+    color = texture(s_sky, view_dir);
 }
 
 

--- a/src/textureset.cc
+++ b/src/textureset.cc
@@ -18,9 +18,14 @@ texture_set::texture_set(GLenum target, int dim, int array_size)
     : texobj(0), dim(dim), array_size(array_size), target(target) {
     glGenTextures(1, &texobj);
     glBindTexture(target, texobj);
-    glTexStorage3D(target,
+    if (target == GL_TEXTURE_CUBE_MAP) {
+        glTexStorage2D(target, 1, GL_RGBA8, dim, dim);
+    }
+    else {
+        glTexStorage3D(target,
             1,   /* no mips! I WANT YOUR EYES TO BLEED -- todo, fix this. */
             GL_RGBA8, dim, dim, array_size);
+    }
     glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 }
@@ -47,15 +52,25 @@ texture_set::load(int slot, char const *filename)
 
     /* bring on DSA... for now, we disturb the tex0 binding */
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(target, texobj);
 
-    /* just blindly upload as if it's RGBA/UNSIGNED_BYTE. TODO: support weirder things */
-    glTexSubImage3D(target, 0,
-                    0, 0, slot,
-                    dim, dim, 1,
-                    surf->format->BytesPerPixel == 4 ? GL_RGBA : GL_RGB,
-                    GL_UNSIGNED_BYTE,
-                    surf->pixels);
+
+    if (target == GL_TEXTURE_CUBE_MAP) {
+        glBindTexture(GL_TEXTURE_CUBE_MAP_POSITIVE_X + slot, texobj);
+        glTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + slot, 0,
+                        0, 0, dim, dim,
+                        surf->format->BytesPerPixel == 4 ? GL_RGBA : GL_RGB,
+                        GL_UNSIGNED_BYTE,
+                        surf->pixels);
+    }
+    else {
+        glBindTexture(target, texobj);
+        glTexSubImage3D(target, 0,
+                        0, 0, slot,
+                        dim, dim, 1,
+                        surf->format->BytesPerPixel == 4 ? GL_RGBA : GL_RGB,
+                        GL_UNSIGNED_BYTE,
+                        surf->pixels);
+    }
 
     SDL_FreeSurface(surf);
 }


### PR DESCRIPTION
Cube texture API is pretty weird, which is why I avoided it. We'd like to
be able to run on R600 though, so let's just deal with it...

Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>