### PR TITLE
Set up valid topology for newly-spawned chunks

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -397,7 +397,7 @@ update_lightfield()
         auto pos = get_block_containing(pos_man.position(ce));
         auto should_emit = power_man.enabled(ce) && power_man.powered(ce);
         if (should_emit) {
-            set_light_level(pos.x, pos.y, pos.z, 255 * light_man.intensity(ce));
+            set_light_level(pos.x, pos.y, pos.z, (int)(255 * light_man.intensity(ce)));
         }
     }
 

--- a/src/ship_space.cc
+++ b/src/ship_space.cc
@@ -285,6 +285,23 @@ ship_space::ensure_chunk(int chunk_x, int chunk_y, int chunk_z)
     if (!ch) {
         ch = new chunk();
         this->_maintain_bounds(chunk_x, chunk_y, chunk_z);
+
+        /* All the topo nodes in the new chunk should be attached
+         * to the outside node.
+         */
+        for (auto k = 0; k < CHUNK_SIZE; k++) {
+            for (auto j = 0; j < CHUNK_SIZE; j++) {
+                for (auto i = 0; i < CHUNK_SIZE; i++) {
+                    topo_info *t = ch->topo.get(i, j, k);
+                    t->p = &this->outside_topo_info;
+                }
+            }
+        }
+
+        /* Adjust the size of the outside chunk. This is currently not
+         * used for anything, but the consistency is nice and the cost is negligible.
+         */
+        this->outside_topo_info.size += CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE;
     }
 }
 


### PR DESCRIPTION
Previously the new topo nodes would have been smashed to zero, which causes problems if we try to walk them before something causes the topology to be rebuilt.

Fixes the crash observed in #205 