### PR TITLE
Frame data

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1186,15 +1186,18 @@ update()
                 /* TODO: prepare all the matrices first, and do ONE upload */
                 chunk *ch = ship->get_chunk(i, j, k);
                 if (ch) {
-                    per_object->val.world_matrix = mat_position(
+                    auto chunk_matrix = frame->alloc_aligned<glm::mat4>(1);
+                    *chunk_matrix.ptr = mat_position(
                                 (float)i * CHUNK_SIZE, (float)j * CHUNK_SIZE, (float)k * CHUNK_SIZE);
-                    per_object->upload();
+                    glBindBufferRange(GL_UNIFORM_BUFFER, 1, frame->bo,
+                                      chunk_matrix.off, chunk_matrix.size);
                     draw_mesh(ch->render_chunk.mesh);
                 }
             }
         }
     }
 
+    per_object->bind(1);
     draw_renderables();
 
     /* draw the projectiles */

--- a/main.cc
+++ b/main.cc
@@ -429,7 +429,7 @@ tick_gas_producers()
 }
 
 void
-draw_renderables()
+draw_renderables(frame_data *frame)
 {
     for (auto i = 0u; i < render_man.buffer.num; i++) {
         auto ce = render_man.instance_pool.entity[i];
@@ -437,8 +437,10 @@ draw_renderables()
         auto mat = pos_man.mat(ce);
         auto mesh = render_man.mesh(ce);
 
-        per_object->val.world_matrix = mat;
-        per_object->upload();
+        auto entity_matrix = frame->alloc_aligned<glm::mat4>(1);
+        *entity_matrix.ptr = mat;
+        entity_matrix.bind(1, frame);
+
         draw_mesh(&mesh);
     }
 }
@@ -1202,8 +1204,9 @@ update()
         }
     }
 
+    draw_renderables(frame);
+
     per_object->bind(1);
-    draw_renderables();
 
     /* draw the projectiles */
     glUseProgram(unlit_shader);

--- a/main.cc
+++ b/main.cc
@@ -102,6 +102,79 @@ gl_debug_callback(GLenum source __unused,
     printf("GL: %s\n", message);
 }
 
+
+// 16M per frame
+#define FRAME_DATA_SIZE     (16u * 1024 * 1024)
+
+
+struct frame_data {
+    GLuint bo;
+    void *base_ptr;
+    size_t offset;
+    GLsync fence;
+    GLint hw_align;
+
+    frame_data() : bo(0), base_ptr(0), offset(0), fence(0), hw_align(1) {
+        glGenBuffers(1, &bo);
+        glBindBuffer(GL_UNIFORM_BUFFER, bo);
+        glBufferStorage(GL_UNIFORM_BUFFER, FRAME_DATA_SIZE, nullptr,
+            GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
+        base_ptr = glMapBufferRange(GL_UNIFORM_BUFFER, 0, FRAME_DATA_SIZE,
+            GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
+        glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &hw_align);
+    }
+
+    /* Prepare for filling this frame_data. If the backing BO is still in flight,
+     * this may stall waiting for the frame to retire.
+     */
+    void begin() {
+        if (fence) {
+            /* Wait on the fence if this frame_data might be in flight. */
+
+            /* TODO: detect case where we are getting throttled by this wait -- it suggests
+             * that either we have insufficient frame_data buffers, or that the driver is
+             * trying to run the GPU an unacceptable number of frames behind.
+             */
+            glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, GL_TIMEOUT_IGNORED);
+            glDeleteSync(fence);
+            fence = 0;
+        }
+
+        offset = 0;
+    }
+
+    /* Signal that all uses of this frame_data have been submitted to the hardware. */
+    void end() {
+        /* All gpu commands using this frame_data have now been issued. Drop a fence
+         * into the pipeline so we know when the buffer can be reused.
+         */
+        fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+    }
+
+    /* A transient GPU memory allocation. Usable until end() is called.
+     */
+    template<typename T>
+    struct alloc
+    {
+        T* ptr;
+        size_t off;
+        size_t size;
+    };
+
+    /* Allocate a chunk of frame_data for an array of T*, aligned appropriately for
+     * use as both a constant buffer, and for CPU access.
+     */
+    template<typename T>
+    alloc<T> alloc_aligned(size_t count, size_t align = alignof(T)) {
+        align = std::max(align, (size_t)hw_align);
+        offset = (offset + align - 1) & ~(align - 1);
+        alloc<T> a{ (T*)(offset + (size_t)base_ptr), offset, count * sizeof(T) };
+        offset += a.size;
+        return a;
+    }
+};
+
+
 sw_mesh *scaffold_sw;
 sw_mesh *surfs_sw[6];
 sw_mesh *projectile_sw;

--- a/main.cc
+++ b/main.cc
@@ -105,7 +105,7 @@ gl_debug_callback(GLenum source __unused,
 
 // 16M per frame
 #define FRAME_DATA_SIZE     (16u * 1024 * 1024)
-
+#define NUM_INFLIGHT_FRAMES 3
 
 struct frame_data {
     GLuint bo;
@@ -174,6 +174,8 @@ struct frame_data {
     }
 };
 
+frame_data *frames;
+unsigned frame_index;
 
 sw_mesh *scaffold_sw;
 sw_mesh *surfs_sw[6];
@@ -732,6 +734,9 @@ init()
     en_settings user_settings = load_settings(en_config_user);
     game_settings.merge_with(user_settings);
 
+    frames = new frame_data[NUM_INFLIGHT_FRAMES];
+    frame_index = 0;
+
     pl.angle = 0;
     pl.elev = 0;
     pl.pos = glm::vec3(3,2,2);
@@ -1079,6 +1084,13 @@ update()
     frame_info.tick();
     auto dt = frame_info.dt;
 
+    frame_data *frame = &frames[frame_index++];
+    if (frame_index >= NUM_INFLIGHT_FRAMES) {
+        frame_index = 0;
+    }
+
+    frame->begin();
+
     float depthClearValue = 1.0f;
     glClearBufferfv(GL_DEPTH, 0, &depthClearValue);
 
@@ -1211,6 +1223,8 @@ update()
     glUseProgram(simple_shader);
 
     glEnable(GL_DEPTH_TEST);
+
+    frame->end();
 }
 
 

--- a/nightmare.vcxproj
+++ b/nightmare.vcxproj
@@ -152,6 +152,7 @@
     <ClInclude Include="src\fixed_grid.h" />
     <ClInclude Include="src\input.h" />
     <ClInclude Include="src\memory.h" />
+    <ClInclude Include="src\light_field.h" />
     <ClInclude Include="src\mesh.h" />
     <ClInclude Include="src\physics.h" />
     <ClInclude Include="src\player.h" />
@@ -159,6 +160,7 @@
     <ClInclude Include="src\scopetimer.h" />
     <ClInclude Include="src\settings.h" />
     <ClInclude Include="src\shader.h" />
+    <ClInclude Include="src\shader_params.h" />
     <ClInclude Include="src\ship_space.h" />
     <ClInclude Include="src\text.h" />
     <ClInclude Include="src\textureset.h" />

--- a/nightmare.vcxproj.filters
+++ b/nightmare.vcxproj.filters
@@ -174,6 +174,12 @@
       <Filter>Header Files\projectile</Filter>
     </ClInclude>
     <ClInclude Include="src\memory.h">
+      <Filter>Header Files\projectile</Filter>
+    </ClInclude>
+    <ClInclude Include="src\light_field.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\shader_params.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/shaders/simple_instanced.vert
+++ b/shaders/simple_instanced.vert
@@ -1,0 +1,56 @@
+#version 330 core
+
+// for uniform block bindings.
+#extension GL_ARB_shading_language_420pack: require
+
+layout(location=0) in vec4 pos;
+layout(location=1) in int mat;
+layout(location=2) in vec3 norm;
+
+
+layout(std140, binding=0) uniform per_camera {
+
+	mat4 view_proj_matrix;
+
+};
+
+
+layout(std140, binding=1) uniform per_object {
+
+	mat4 world_matrix[256];
+
+};
+
+
+out vec3 texcoord;
+out vec3 ws_pos;
+out vec3 ws_norm;
+
+void main(void)
+{
+	mat4 world_mat = world_matrix[gl_InstanceID];
+
+    vec4 world_pos = world_mat * pos;
+	gl_Position = view_proj_matrix * world_pos;
+    texcoord.z = mat;
+
+    vec3 n = normalize(mat3(world_mat) * norm);
+
+    /* Quick & dirty triplanar mapping */
+    if (n.x > 0.8) {
+        texcoord.xy = vec2(-world_pos.y, -world_pos.z);
+	} else if (n.x < -0.8) {
+        texcoord.xy = vec2(world_pos.y, -world_pos.z);
+    } else if (n.y > 0.8) {
+        texcoord.xy = vec2(world_pos.x, -world_pos.z);
+	} else if (n.y < -0.8) {
+		texcoord.xy = vec2(-world_pos.x, -world_pos.z);
+    } else if (n.z < -0.8) {
+		texcoord.xy = vec2(world_pos.x, -world_pos.y);
+	} else {
+        texcoord.xy = world_pos.xy;
+    }
+
+    ws_pos = world_pos.xyz;
+    ws_norm = n;
+}

--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -124,6 +124,15 @@ draw_mesh(hw_mesh *m)
 
 
 void
+draw_mesh_instanced(hw_mesh *m, unsigned num_instances)
+{
+    glBindVertexArray(m->vao);
+    glDrawElementsInstanced(GL_TRIANGLES, m->num_indices,
+                            GL_UNSIGNED_INT, nullptr, num_instances);
+}
+
+
+void
 free_mesh(hw_mesh *m)
 {
     /* TODO: try to reuse BO */

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -46,3 +46,4 @@ hw_mesh *upload_mesh(sw_mesh *mesh);
 void set_mesh_material(sw_mesh *m, int material);
 void draw_mesh(hw_mesh *m);
 void free_mesh(hw_mesh *m);
+void draw_mesh_instanced(hw_mesh *m, unsigned num_instances);

--- a/src/projectile/projectile.cc
+++ b/src/projectile/projectile.cc
@@ -78,20 +78,6 @@ projectile_manager::spawn(glm::vec3 pos, glm::vec3 dir, hw_mesh m) {
     mesh(index) = m;
 }
 
-void
-projectile_manager::draw() {
-    for (auto i = 0u; i < buffer.num; ++i) {
-        /* TODO: instancing etc to get rid of this upload/draw loop */
-
-        auto pos = projectile_pool.position[i];
-        auto mesh = projectile_pool.mesh;
-
-        per_object->val.world_matrix = mat_position(pos);
-        per_object->upload();
-        draw_mesh(mesh);
-    }
-}
-
 void projectile_linear_manager::simulate(float dt) {
     for (auto i = 0u; i < buffer.num; ) {
         auto new_pos = projectile_pool.position[i] + projectile_pool.velocity[i] * dt;

--- a/src/projectile/projectile.h
+++ b/src/projectile/projectile.h
@@ -22,7 +22,7 @@ struct projectile_manager {
     float initial_lifetime = 10.f;
     float after_collision_lifetime = 0.5f;
 
-    projectile_manager(){
+    projectile_manager() {
     }
 
     virtual void create_projectile_data(unsigned count);
@@ -32,8 +32,6 @@ struct projectile_manager {
     virtual void simulate(float dt) = 0;
 
     virtual void spawn(glm::vec3 pos, glm::vec3 vel, hw_mesh m);
-
-    virtual void draw();
 
     float & mass(unsigned index) {
         return projectile_pool.mass[index];

--- a/src/shader_params.h
+++ b/src/shader_params.h
@@ -44,5 +44,5 @@ struct per_object_params {
     glm::mat4 world_matrix;
 };
 
-extern shader_params<per_camera_params> *per_camera;
+
 extern shader_params<per_object_params> *per_object;


### PR DESCRIPTION
This switches us to use ARB_buffer_storage's persistently-mapped buffers for most small uploads, rather than using the shader_params<T> UBO path. This gives much better performance on AMD 7xxx, and should give more *consistent* performance everywhere.