### PR TITLE
First part of rationalizing wiring system

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1068,9 +1068,6 @@ struct add_wiring_tool : tool
     void preview(raycast_info *rc) override {
         /* do a real, generic raycast */
 
-        /* TODO: handle some weird cases in negative space. current impl is
-         * not quite correct */
-
         /* TODO: Move the assignment logic into the wiring system */
 
         bool hit_entity;

--- a/main.cc
+++ b/main.cc
@@ -772,6 +772,14 @@ remove_ents_from_surface(int x, int y, int z, int face)
     for (auto it = ch->entities.begin(); it != ch->entities.end(); /* */) {
         entity *e = *it;
 
+        /* entities may have been inserted in this chunk which don't have
+         * placement on a surface. don't corrupt everything if we hit one.
+         */
+        if (!surface_man.exists(e->ce)) {
+            ++it;
+            continue;
+        }
+
         const auto & p = surface_man.block(e->ce);
         const auto & f = surface_man.face(e->ce);
 

--- a/src/wiring.cc
+++ b/src/wiring.cc
@@ -6,7 +6,7 @@ hw_mesh *attachment_hw;
 sw_mesh *attachment_sw;
 
 std::vector<wire_attachment> wire_attachments;
-std::vector<wire> wires;
+std::vector<wire_segment> wire_segments;
 
 bool segment_finished(wire_segment* segment) {
     if (!segment) {

--- a/src/wiring.cc
+++ b/src/wiring.cc
@@ -1,23 +1,30 @@
 #include "wiring.h"
-
 #include "mesh.h"
 
-hw_mesh *attachment_hw;
+
 sw_mesh *attachment_sw;
+hw_mesh *attachment_hw;
+sw_mesh *wire_sw;
+hw_mesh *wire_hw;
+
 
 std::vector<wire_attachment> wire_attachments;
 std::vector<wire_segment> wire_segments;
 
-bool segment_finished(wire_segment* segment) {
-    if (!segment) {
-        return true;
-    }
 
-    return segment->first != ~0u && segment->second != ~0u;
-}
+extern glm::mat4
+mat_scale(glm::vec3 scale);
+
+extern glm::mat4
+mat_scale(float x, float y, float z);
+
+extern glm::mat4
+mat_rotate_mesh(glm::vec3 pt, glm::vec3 dir);
+
 
 void
-draw_attachments(frame_data *frame) {
+draw_attachments(frame_data *frame)
+{
     auto count = wire_attachments.size();
     for (auto i = 0u; i < count; i += INSTANCE_BATCH_SIZE) {
         auto batch_size = std::min(INSTANCE_BATCH_SIZE, (unsigned)(count - i));
@@ -29,5 +36,56 @@ draw_attachments(frame_data *frame) {
 
         attachment_matrices.bind(1, frame);
         draw_mesh_instanced(attachment_hw, batch_size);
+    }
+}
+
+
+glm::mat4
+calc_segment_matrix(const wire_attachment &start, const wire_attachment &end) {
+    auto a1 = start.transform;
+    auto a2 = end.transform;
+
+    auto p1_4 = a1[3];
+    auto p2_4 = a2[3];
+
+    auto p1 = glm::vec3(p1_4.x, p1_4.y, p1_4.z);
+    auto p2 = glm::vec3(p2_4.x, p2_4.y, p2_4.z);
+
+    auto seg = p1 - p2;
+    auto len = glm::length(seg);
+
+    auto scale = mat_scale(1, 1, len);
+
+    auto rot = mat_rotate_mesh(p2, glm::normalize(p2 - p1));
+
+    return rot * scale;
+}
+
+
+void
+draw_segments(frame_data *frame)
+{
+    auto count = wire_segments.size();
+    for (auto i = 0u; i < count; i += INSTANCE_BATCH_SIZE) {
+        auto batch_size = std::min(INSTANCE_BATCH_SIZE, (unsigned)(count - i));
+        auto segment_matrices = frame->alloc_aligned<glm::mat4>(batch_size);
+
+        auto added = 0u;
+        for (auto j = 0u; j < batch_size; j++) {
+            auto segment = wire_segments[i + j];
+
+            auto a1 = wire_attachments[segment.first];
+            auto a2 = wire_attachments[segment.second];
+
+            auto mat = calc_segment_matrix(a1, a2);
+
+            segment_matrices.ptr[added] = mat;
+            ++added;
+        }
+
+        if (added) {
+            segment_matrices.bind(1, frame);
+            draw_mesh_instanced(wire_hw, added);
+        }
     }
 }

--- a/src/wiring.cc
+++ b/src/wiring.cc
@@ -70,7 +70,6 @@ draw_segments(frame_data *frame)
         auto batch_size = std::min(INSTANCE_BATCH_SIZE, (unsigned)(count - i));
         auto segment_matrices = frame->alloc_aligned<glm::mat4>(batch_size);
 
-        auto added = 0u;
         for (auto j = 0u; j < batch_size; j++) {
             auto segment = wire_segments[i + j];
 
@@ -79,13 +78,10 @@ draw_segments(frame_data *frame)
 
             auto mat = calc_segment_matrix(a1, a2);
 
-            segment_matrices.ptr[added] = mat;
-            ++added;
+            segment_matrices.ptr[j] = mat;
         }
 
-        if (added) {
-            segment_matrices.bind(1, frame);
-            draw_mesh_instanced(wire_hw, added);
-        }
+        segment_matrices.bind(1, frame);
+        draw_mesh_instanced(wire_hw, batch_size);
     }
 }

--- a/src/wiring.h
+++ b/src/wiring.h
@@ -7,15 +7,19 @@
 
 struct wire_attachment {
     glm::mat4 transform;
+    unsigned parent;
 };
 
 struct wire_segment {
-    unsigned first = -1;
-    unsigned second = -1;
+    unsigned first;
+    unsigned second;
 };
-
-bool
-segment_finished(wire_segment* segment);
 
 void
 draw_attachments(frame_data *frame);
+
+void
+draw_segments(frame_data *frame);
+
+glm::mat4
+calc_segment_matrix(const wire_attachment &start, const wire_attachment &end);

--- a/src/wiring.h
+++ b/src/wiring.h
@@ -14,11 +14,6 @@ struct wire_segment {
     unsigned second = -1;
 };
 
-struct wire {
-    std::vector<wire_segment> segments;
-};
-
-
 bool
 segment_finished(wire_segment* segment);
 


### PR DESCRIPTION
Just flattening the second layer of std::vector out of existence. Should be no user-facing change, but we'll get better batching of wire segment instances now.

In prep for inducing the topology over the segments.