### PR TITLE
Hit wiring with the union-find hammer

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1072,7 +1072,7 @@ struct add_wiring_tool : tool
             return;
 
         unsigned new_attach = wire_attachments.size();
-        wire_attachment wa = { mat_rotate_mesh(pt, normal) };
+        wire_attachment wa = { mat_rotate_mesh(pt, normal), new_attach };
         wire_attachments.push_back(wa);
 
         if (current_attach != (unsigned)-1) {

--- a/main.cc
+++ b/main.cc
@@ -1072,7 +1072,7 @@ struct add_wiring_tool : tool
             return;
 
         unsigned new_attach = wire_attachments.size();
-        wire_attachment wa = { mat_rotate_mesh(pt, normal), new_attach };
+        wire_attachment wa = { mat_rotate_mesh(pt, normal), new_attach, 0 };
         wire_attachments.push_back(wa);
 
         if (current_attach != (unsigned)-1) {
@@ -1080,6 +1080,9 @@ struct add_wiring_tool : tool
             s.first = current_attach;
             s.second = new_attach;
             wire_segments.push_back(s);
+
+            /* merge! */
+            attach_topo_unite(current_attach, new_attach);
         }
 
         if (hit_entity && current_attach != (unsigned)-1) {

--- a/src/wiring.h
+++ b/src/wiring.h
@@ -8,6 +8,7 @@
 struct wire_attachment {
     glm::mat4 transform;
     unsigned parent;
+    unsigned rank;
 };
 
 struct wire_segment {
@@ -23,3 +24,7 @@ draw_segments(frame_data *frame);
 
 glm::mat4
 calc_segment_matrix(const wire_attachment &start, const wire_attachment &end);
+
+
+unsigned
+attach_topo_unite(unsigned from, unsigned to);


### PR DESCRIPTION
Adds support for building the set of connected-components over the wiring graph. Since we're currently add-only, this works purely incrementally. Deletes require more work (worst case is a complete rebuild)