### PR TITLE
Wiring move

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1207,6 +1207,8 @@ struct add_wiring_tool : tool
                         segment.second = current_attach;
                     }
                 }
+
+                attach_topo_rebuild();
             }
 
             moving_existing = false;

--- a/main.cc
+++ b/main.cc
@@ -840,6 +840,8 @@ struct add_block_entity_tool : tool
 
     void alt_use(raycast_info *rc) override {}
 
+    void long_use(raycast_info *rc) override {}
+
     void preview(raycast_info *rc) override {
         if (!can_use(rc))
             return;
@@ -920,6 +922,8 @@ struct add_surface_entity_tool : tool
 
     void alt_use(raycast_info *rc) override {}
 
+    void long_use(raycast_info *rc) override {}
+
     void preview(raycast_info *rc) override {
         if (!can_use(rc))
             return;
@@ -969,6 +973,8 @@ struct remove_surface_entity_tool : tool
     }
 
     void alt_use(raycast_info *rc) override {}
+
+    void long_use(raycast_info *rc) override {}
 
     void preview(raycast_info *rc) override {
         if (!can_use(rc))
@@ -1235,6 +1241,8 @@ struct add_wiring_tool : tool
             attach_topo_rebuild();
         }
     }
+
+    void long_use(raycast_info *rc) override {}
 
     void get_description(char *str) override {
         strcpy(str, "Place wiring");
@@ -1577,6 +1585,10 @@ struct play_state : game_state {
             t->alt_use(&rc);
         }
 
+        if (pl.long_use_tool && t) {
+            t->long_use(&rc);
+        }
+
         /* interact with ents */
         entity *hit_ent = phys_raycast(pl.eye, pl.eye + 2.f * pl.dir,
                                        phy->ghostObj, phy->dynamicsWorld);
@@ -1638,10 +1650,14 @@ struct play_state : game_state {
         auto slot9      = get_input(action_slot9)->just_active;
         auto slot0      = get_input(action_slot0)->just_active;
         auto gravity    = get_input(action_gravity)->just_active;
-        auto use_tool   = get_input(action_use_tool)->just_pressed;
-        auto alt_use_tool = get_input(action_alt_use_tool)->just_pressed;
         auto next_tool  = get_input(action_tool_next)->just_active;
         auto prev_tool  = get_input(action_tool_prev)->just_active;
+
+        auto input_use_tool     = get_input(action_use_tool);
+        auto use_tool           = input_use_tool->just_pressed;
+        auto long_use_tool      = input_use_tool->held;
+        auto input_alt_use_tool = get_input(action_alt_use_tool);
+        auto alt_use_tool       = input_alt_use_tool->just_pressed;
 
         /* persistent */
 
@@ -1657,14 +1673,15 @@ struct play_state : game_state {
 
         pl.move = glm::vec2((float) moveX, (float) moveY);
 
-        pl.jump       = jump;
-        pl.crouch     = crouch;
-        pl.reset      = reset;
-        pl.crouch_end = crouch_end;
-        pl.use        = use;
-        pl.gravity    = gravity;
-        pl.use_tool   = use_tool;
-        pl.alt_use_tool = alt_use_tool;
+        pl.jump          = jump;
+        pl.crouch        = crouch;
+        pl.reset         = reset;
+        pl.crouch_end    = crouch_end;
+        pl.use           = use;
+        pl.gravity       = gravity;
+        pl.use_tool      = use_tool;
+        pl.alt_use_tool  = alt_use_tool;
+        pl.long_use_tool = long_use_tool;
 
         // blech. Tool gets used below, then fire projectile gets hit here
         if (pl.fire_projectile) {

--- a/src/player.h
+++ b/src/player.h
@@ -26,8 +26,8 @@ struct player {
     bool gravity;
 
     bool use_tool;
-
-    bool alt_use_tool;
+    bool alt_use_tool;    
+    bool long_use_tool;
 
     bool ui_dirty;
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -12,6 +12,7 @@ struct tool
 
     virtual void use(raycast_info *rc) = 0;
     virtual void alt_use(raycast_info *rc) = 0;
+    virtual void long_use(raycast_info *rc) = 0;
     virtual void preview(raycast_info *rc) = 0;
     virtual void get_description(char *str) = 0;
 

--- a/src/tools/add_block.cc
+++ b/src/tools/add_block.cc
@@ -47,6 +47,8 @@ struct add_block_tool : tool
 
     void alt_use(raycast_info *rc) override {}
 
+    void long_use(raycast_info *rc) override {}
+
     void preview(raycast_info *rc) override
     {
         if (!can_use(rc))

--- a/src/tools/add_surface.cc
+++ b/src/tools/add_surface.cc
@@ -74,6 +74,8 @@ struct add_surface_tool : tool
 
     void alt_use(raycast_info *rc) override {}
 
+    void long_use(raycast_info *rc) override {}
+
     void preview(raycast_info *rc) override
     {
         if (!rc->hit)

--- a/src/tools/fire_projectile.cc
+++ b/src/tools/fire_projectile.cc
@@ -20,6 +20,8 @@ struct fire_projectile_tool : tool
 
     void alt_use(raycast_info *rc) override {}
 
+    void long_use(raycast_info *rc) override {}
+
     void preview(raycast_info *rc) override
     {
     }

--- a/src/tools/remove_block.cc
+++ b/src/tools/remove_block.cc
@@ -90,6 +90,8 @@ struct remove_block_tool : tool
 
     void alt_use(raycast_info *rc) override {}
 
+    void long_use(raycast_info *rc) override {}
+
     void preview(raycast_info *rc) override
     {
         if (!can_use(rc))

--- a/src/tools/remove_surface.cc
+++ b/src/tools/remove_surface.cc
@@ -72,6 +72,8 @@ struct remove_surface_tool : tool
 
     void alt_use(raycast_info *rc) override {}
 
+    void long_use(raycast_info *rc) override {}
+
     void preview(raycast_info *rc) override
     {
         if (!can_use(rc))


### PR DESCRIPTION
This allows wire attachments to be moved.
  Long press primary use to initiate attach moving.
  Primary use to accept new.
  Alternate use to revert back.

Removes attach snap to edge logic. See #257
Closes #247
Closes #249
