### PR TITLE
main: fix double-free of rigid bodies

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -247,6 +247,7 @@ struct entity
         type_man.type(ce) = type;
 
         physics_man.assign_entity(ce);
+        physics_man.rigid(ce) = nullptr;
         build_static_physics_rb_mat(&mat, et->phys_shape, &physics_man.rigid(ce));
         /* so that we can get back to the entity from a phys raycast */
         physics_man.rigid(ce)->setUserPointer(this);


### PR DESCRIPTION
If the physics component's instance data was moved (to cover a deletion),
a stale copy of the data is left behind in the vacated slot. When another
component instance is allocated, it inherits that slot. Logic in mesher.cc
assumed that if the rb ptr was non-null, it already had an rb to update
(which is important for the chunk mesher itself). Later deleting this
component instance would double-free the rb object.

Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>