### PR TITLE
Wiring entity remove

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -798,7 +798,7 @@ remove_ents_from_surface(int x, int y, int z, int face)
                     if (swap_index > rem) {
                         ship->wire_attachments[rem] = from_attach;
                         ship->wire_attachments.pop_back();
-                        fixup_attaches_removed[rem] = swap_index;
+                        fixup_attaches_removed[rem] = (unsigned)swap_index;
                         --swap_index;
                         ++s;
                     }
@@ -1200,7 +1200,7 @@ struct add_wiring_tool : tool
             if (existing_attach != invalid_attach) {
                 relocate_segments_and_entity_attaches(ship, existing_attach, current_attach);
 
-                auto back_attach = ship->wire_attachments.size() - 1;
+                auto back_attach = (unsigned)ship->wire_attachments.size() - 1;
                 /* no segments */
                 if (back_attach != invalid_attach) {
                     ship->wire_attachments[current_attach] = ship->wire_attachments[back_attach];

--- a/main.cc
+++ b/main.cc
@@ -1193,9 +1193,10 @@ struct add_wiring_tool : tool
             return;
 
         if (moving_existing) {
+            /* did we just move to an already existing attach */
             unsigned existing_attach = get_existing_attach_near(pt, current_attach);
 
-            /* moved to existing. need to merge
+            /* we did move to an existing. need to merge
              */
             if (existing_attach != invalid_attach) {
                 relocate_segments_and_entity_attaches(ship, existing_attach, current_attach);
@@ -1210,10 +1211,14 @@ struct add_wiring_tool : tool
 
                     attach_topo_rebuild(ship);
                 }
+
+                /* update current */
+                current_attach = existing_attach;
             }
 
-            if (hit_entity && existing_attach != invalid_attach) {
-                ship->entity_to_attach_lookup[hit_entity->ce.id].insert(existing_attach);
+            /* did we move to be on an entity */
+            if (hit_entity && current_attach != invalid_attach) {
+                ship->entity_to_attach_lookup[hit_entity->ce.id].insert(current_attach);
             }
 
             moving_existing = false;

--- a/main.cc
+++ b/main.cc
@@ -1145,6 +1145,10 @@ struct add_wiring_tool : tool
                 }
             }
 
+            if (hit_entity && existing_attach != invalid_attach) {
+                ship->entity_to_attach_lookup[hit_entity->ce.id].insert(existing_attach);
+            }
+
             moving_existing = false;
             current_attach = invalid_attach;
         }
@@ -1177,7 +1181,12 @@ struct add_wiring_tool : tool
             else {
                 current_attach = new_attach;
             }
+
+            if (hit_entity && current_attach != invalid_attach) {
+                ship->entity_to_attach_lookup[hit_entity->ce.id].insert(current_attach);
+            }
         }
+
         reduce_segments(ship);
     }
 
@@ -1185,6 +1194,12 @@ struct add_wiring_tool : tool
         /* reset to old spot if moving. "cancel" */
         if (moving_existing) {
             ship->wire_attachments[current_attach] = old_attach;
+
+            if (old_entity) {
+                ship->entity_to_attach_lookup[old_entity->ce.id].insert(current_attach);
+                old_entity = nullptr;
+            }
+
             moving_existing = false;
             current_attach = invalid_attach;
             return;
@@ -1245,8 +1260,17 @@ struct add_wiring_tool : tool
 
             current_attach = existing_attach;
 
+            /* remove this attach from entity attaches
+             * will get added back if needed in use()/alt_use()
+             */
+            auto & lookup = ship->entity_to_attach_lookup;
+            if (hit_entity && lookup.find(hit_entity->ce.id) != lookup.end()) {
+                lookup[hit_entity->ce.id].erase(current_attach);
+            }
+
             moving_existing = true;
             old_attach = ship->wire_attachments[current_attach];
+            old_entity = hit_entity;
         }
     }
 

--- a/main.cc
+++ b/main.cc
@@ -1008,6 +1008,7 @@ struct add_wiring_tool : tool
     unsigned current_attach = invalid_attach;
     bool moving_existing = false;
     wire_attachment old_attach;
+    entity *old_entity = nullptr;
 
     unsigned get_existing_attach_near(glm::vec3 const & pt, unsigned ignore = invalid_attach) {
         /* Some spatial index might be useful here. */
@@ -1026,11 +1027,11 @@ struct add_wiring_tool : tool
         return invalid_attach;
     }
 
-    bool get_attach_point(bool & is_entity, glm::vec3 & pt, glm::vec3 & normal) {
+    bool get_attach_point(entity ** hit_entity, glm::vec3 & pt, glm::vec3 & normal) {
         auto end = pl.eye + pl.dir * 5.0f;
 
-        is_entity = nullptr != phys_raycast(pl.eye, end,
-                                                  phy->ghostObj, phy->dynamicsWorld);
+        *hit_entity = phys_raycast(pl.eye, end,
+                                    phy->ghostObj, phy->dynamicsWorld);
 
         auto hit = phys_raycast_generic(pl.eye, end,
                                         phy->ghostObj, phy->dynamicsWorld);
@@ -1050,11 +1051,11 @@ struct add_wiring_tool : tool
 
         /* TODO: Move the assignment logic into the wiring system */
 
-        bool hit_entity;
+        entity *hit_entity = nullptr;
         glm::vec3 pt;
         glm::vec3 normal;
 
-        if (!get_attach_point(hit_entity, pt, normal)) {
+        if (!get_attach_point(&hit_entity, pt, normal)) {
             return;
         }
 
@@ -1117,11 +1118,11 @@ struct add_wiring_tool : tool
     }
 
     void use(raycast_info *rc) override {
-        bool hit_entity;
+        entity *hit_entity = nullptr;
         glm::vec3 pt;
         glm::vec3 normal;
 
-        if (!get_attach_point(hit_entity, pt, normal))
+        if (!get_attach_point(&hit_entity, pt, normal))
             return;
 
         if (moving_existing) {
@@ -1216,11 +1217,11 @@ struct add_wiring_tool : tool
         }
 
         /* remove existing attach, and dependent segments */
-        bool hit_entity;
+        entity *hit_entity = nullptr;
         glm::vec3 pt;
         glm::vec3 normal;
 
-        if (!get_attach_point(hit_entity, pt, normal)) {
+        if (!get_attach_point(&hit_entity, pt, normal)) {
             return;
         }
 
@@ -1269,13 +1270,13 @@ struct add_wiring_tool : tool
     }
 
     void long_use(raycast_info *rc) override {
-        bool hit_entity;
+        entity *hit_entity = nullptr;
         glm::vec3 pt;
         glm::vec3 normal;
         unsigned existing_attach;
 
         if (current_attach == invalid_attach) {
-            if (!get_attach_point(hit_entity, pt, normal))
+            if (!get_attach_point(&hit_entity, pt, normal))
                 return;
 
             existing_attach = get_existing_attach_near(pt);

--- a/main.cc
+++ b/main.cc
@@ -764,6 +764,73 @@ remove_ents_from_surface(int x, int y, int z, int face)
 
             type_man.destroy_entity_instance(e->ce);
 
+            /* left side is the index of attach on entity that we're removing
+             * right side is the index we moved from the end into left side
+             * 0, 2 would be read as "attach at index 2 moved to index 0
+             * and assumed that what was at index 0 is no longer valid in referencers
+             */
+            std::unordered_map<unsigned, unsigned> fixup_attaches_removed;
+            auto entity_attaches = ship->entity_to_attach_lookup.find(e->ce.id);
+            if (entity_attaches != ship->entity_to_attach_lookup.end()) {
+                auto set = entity_attaches->second;
+                auto attaches = std::vector<unsigned>(set.begin(), set.end());
+                std::sort(attaches.begin(), attaches.end());
+
+                auto att_size = attaches.size();
+                for (size_t i = 0; i < att_size; ++i) {
+                    auto attach = attaches[i];
+
+                    // fill left side of fixup map
+                    fixup_attaches_removed[attach] = 0;
+                }
+
+                /* Remove relevant attaches from wire_attachments
+                 * relevant is an attach that isn't occupying a position
+                 * will get popped off as a result of moving before removing
+                 */
+                auto att_index = attaches.size() - 1;
+                auto swap_index = ship->wire_attachments.size() - 1;
+                for (auto s = ship->wire_attachments.rbegin();
+                    s != ship->wire_attachments.rend() && att_index != -1;) {
+
+                    auto from_attach = ship->wire_attachments[swap_index];
+                    auto rem = attaches[att_index];
+                    if (swap_index > rem) {
+                        ship->wire_attachments[rem] = from_attach;
+                        ship->wire_attachments.pop_back();
+                        fixup_attaches_removed[rem] = swap_index;
+                        --swap_index;
+                        ++s;
+                    }
+                    else if (s != ship->wire_attachments.rend() && swap_index == rem) {
+                        ship->wire_attachments.pop_back();
+                        fixup_attaches_removed.erase(rem);
+                        --swap_index;
+                        ++s;
+                    }
+
+                    --att_index;
+                }
+
+                /* remove all segments that contain an attach on entity */
+                for (auto remove_attach : attaches) {
+                    remove_segments_containing(ship, remove_attach);
+                }
+
+                /* remove attaches assigned to entity from ship lookup */
+                ship->entity_to_attach_lookup.erase(e->ce.id);
+
+                for (auto lookup : fixup_attaches_removed) {
+                    /* we moved m to position r */
+                    auto r = lookup.first;
+                    auto m = lookup.second;
+
+                    relocate_segments_and_entity_attaches(ship, r, m);
+                }
+
+                attach_topo_rebuild(ship);
+            }
+
             delete e;
             it = ch->entities.erase(it);
         }

--- a/main.cc
+++ b/main.cc
@@ -699,7 +699,7 @@ init()
     unlit_ui_slot_sprite = ui_sprites->load("textures/ui-slot.png");
     lit_ui_slot_sprite = ui_sprites->load("textures/ui-slot-lit.png");
 
-    printf("World vertex size: %lu bytes\n", sizeof(vertex));
+    printf("World vertex size: %zu bytes\n", sizeof(vertex));
 
     light = new light_field();
     light->bind(1);
@@ -1171,7 +1171,7 @@ struct add_wiring_tool : tool
             unsigned existing_attach = get_existing_attach_near(pt);
             unsigned new_attach;
             if (existing_attach == invalid_attach) {
-                new_attach = ship->wire_attachments.size();
+                new_attach = (unsigned)ship->wire_attachments.size();
                 wire_attachment wa = { mat_rotate_mesh(pt, normal), new_attach, 0 };
                 ship->wire_attachments.push_back(wa);
             }
@@ -1238,7 +1238,7 @@ struct add_wiring_tool : tool
          * if we changed any segments, note that we need to rebuild the topology.
          */
         bool changed = false;
-        unsigned attach_moving_for_delete = ship->wire_attachments.size() - 1;
+        unsigned attach_moving_for_delete = (unsigned)ship->wire_attachments.size() - 1;
 
         for (auto it = ship->wire_segments.begin(); it != ship->wire_segments.end(); ) {
             if (it->first == existing_attach || it->second == existing_attach) {
@@ -1661,7 +1661,7 @@ struct play_state : game_state {
     }
 
     void cycle_slot(int d) {
-        auto num_tools = sizeof(tools) / sizeof(tools[0]);
+        unsigned num_tools = sizeof(tools) / sizeof(tools[0]);
         unsigned int cur_slot = pl.selected_slot;
         cur_slot = (cur_slot + num_tools + d) % num_tools;
 
@@ -1771,7 +1771,7 @@ struct menu_state : game_state
 {
     typedef std::pair<char const *, std::function<void()>> menu_item;
     std::vector<menu_item> items;
-    int selected = 0;
+    unsigned selected = 0;
 
     menu_state() : items() {
         items.push_back(menu_item("Resume Game", []{ set_game_state(create_play_state()); }));
@@ -1785,7 +1785,7 @@ struct menu_state : game_state
         }
     }
 
-    void put_item_text(char *dest, char const *src, int index) {
+    void put_item_text(char *dest, char const *src, unsigned index) {
         if (index == selected)
             sprintf(dest, "> %s <", src);
         else
@@ -1807,7 +1807,7 @@ struct menu_state : game_state
         for (auto it = items.begin(); it != items.end(); it++) {
             w = 0;
             h = 0;
-            put_item_text(buf, it->first, it - items.begin());
+            put_item_text(buf, it->first, (unsigned)(it - items.begin()));
             text->measure(buf, &w, &h);
             add_text_with_outline(buf, -w/2, y);
             y += dy;
@@ -1825,7 +1825,7 @@ struct menu_state : game_state
         }
 
         if (get_input(action_menu_up)->just_active) {
-            selected = (selected + items.size() - 1) % items.size();
+            selected = (unsigned)(selected + items.size() - 1) % items.size();
             pl.ui_dirty = true;
         }
 
@@ -1850,7 +1850,7 @@ struct menu_settings_state : game_state
     Uint32 mouse_invert_mi = 0;
 
     menu_settings_state() {
-        mouse_invert_mi = items.size();
+        mouse_invert_mi = (unsigned)items.size();
         items.push_back(menu_item(invert_mouse_text, "",
             []{ toggle_mouse_invert(); }));
             // ^^ Not real keen on requiring these to be static
@@ -1902,7 +1902,7 @@ struct menu_settings_state : game_state
             w = 0;
             h = 0;
             sprintf(buf2, "%s%s", std::get<0>(*it), std::get<1>(*it));
-            put_item_text(buf, buf2, it - items.begin());
+            put_item_text(buf, buf2, (unsigned)(it - items.begin()));
             text->measure(buf, &w, &h);
             add_text_with_outline(buf, -w / 2, y);
             y += dy;
@@ -1922,7 +1922,7 @@ struct menu_settings_state : game_state
         }
 
         if (get_input(action_menu_up)->just_active) {
-            selected = (selected + items.size() - 1) % items.size();
+            selected = (unsigned)(selected + items.size() - 1) % items.size();
             pl.ui_dirty = true;
         }
 

--- a/main.cc
+++ b/main.cc
@@ -1246,13 +1246,7 @@ struct add_wiring_tool : tool
                 attach_topo_unite(ship, current_attach, new_attach);
             }
 
-            if (existing_attach != invalid_attach && current_attach != invalid_attach) {
-                /* finishing a run */
-                current_attach = invalid_attach;
-            }
-            else {
-                current_attach = new_attach;
-            }
+            current_attach = new_attach;
 
             if (hit_entity && current_attach != invalid_attach) {
                 ship->entity_to_attach_lookup[hit_entity->ce.id].insert(current_attach);

--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -51,7 +51,7 @@ load_mesh(char const *filename) {
 
         // when we have many submeshes we need to rebase the indices.
         // NOTE: we assume that all mesh origins coincide, so we're not applying transforms here
-        int submesh_base = verts.size();
+        auto submesh_base = (unsigned)verts.size();
 
         for (unsigned int j = 0; j < m->mNumVertices; j++)
             verts.push_back(vertex(m->mVertices[j].x, m->mVertices[j].y, m->mVertices[j].z,
@@ -67,13 +67,13 @@ load_mesh(char const *filename) {
         }
     }
 
-    printf("\tAfter processing: %lu verts, %lu indices\n", verts.size(), indices.size());
+    printf("\tAfter processing: %zu verts, %zu indices\n", verts.size(), indices.size());
 
     aiReleaseImport(scene);
 
     sw_mesh *ret = new sw_mesh;
-    ret->num_vertices = verts.size();
-    ret->num_indices = indices.size();
+    ret->num_vertices = (unsigned)verts.size();
+    ret->num_indices = (unsigned)indices.size();
     ret->verts = new vertex[verts.size()];
     memcpy(ret->verts, &verts[0], sizeof(vertex) * verts.size());
     ret->indices = new unsigned int[indices.size()];

--- a/src/mesher.cc
+++ b/src/mesher.cc
@@ -17,7 +17,7 @@ static void
 stamp_at_offset(std::vector<vertex> *verts, std::vector<unsigned> *indices,
                 sw_mesh *src, glm::vec3 offset, int mat)
 {
-    unsigned index_base = verts->size();
+    unsigned index_base = (unsigned)verts->size();
 
     for (unsigned int i = 0; i < src->num_vertices; i++) {
         vertex v = src->verts[i];
@@ -184,8 +184,8 @@ chunk::prepare_render(int x, int y, int z)
     sw_mesh m;
     m.verts = &verts[0];
     m.indices = &indices[0];
-    m.num_vertices = verts.size();
-    m.num_indices = indices.size();
+    m.num_vertices = (unsigned)verts.size();
+    m.num_indices = (unsigned)indices.size();
 
     // TODO: try to reuse memory
     if (this->render_chunk.mesh) {

--- a/src/shader.cc
+++ b/src/shader.cc
@@ -16,7 +16,7 @@ load_stage(GLenum stage, char const *filename)
     blob content(filename);
     GLuint shader = glCreateShader(stage);
     glObjectLabel(GL_SHADER, shader, -1, filename);
-    GLint len = content.len;
+    GLint len = (GLint)content.len;
     glShaderSource(shader, 1, (GLchar const **) &content.data, &len);
     glCompileShader(shader);
     return shader;

--- a/src/ship_space.h
+++ b/src/ship_space.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <glm/glm.hpp> /* ivec3 */
+#include <set>
+#include <unordered_map>
+
 #include "block.h"
+#include "component/component_manager.h"
 #include "chunk.h"
 #include "wiring.h"
-
-#include <glm/glm.hpp> /* ivec3 */
-#include <unordered_map>
 
 struct ivec3_hash {
   size_t operator()(const glm::ivec3 &v) const {
@@ -52,6 +54,8 @@ struct ship_space {
 
     std::vector<wire_attachment> wire_attachments;
     std::vector<wire_segment> wire_segments;
+
+    std::unordered_map<unsigned, std::set<unsigned>> entity_to_attach_lookup;
 
     /* create an empty ship_space */
     ship_space();

--- a/src/sprites.cc
+++ b/src/sprites.cc
@@ -83,12 +83,12 @@ sprite_renderer::upload()
     /* Exact-fit is pretty lousy as a growth strategy, but oh well */
     if (verts.size() > bo_capacity) {
         glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(sprite_vertex), &verts[0], GL_STREAM_DRAW);
-        bo_capacity = verts.size();
-        bo_vertex_count = verts.size();
+        bo_capacity = (GLuint)verts.size();
+        bo_vertex_count = (GLuint)verts.size();
     }
     else {
         glBufferSubData(GL_ARRAY_BUFFER, 0, verts.size() * sizeof(sprite_vertex), &verts[0]);
-        bo_vertex_count = verts.size();
+        bo_vertex_count = (GLuint)verts.size();
     }
 }
 

--- a/src/text.cc
+++ b/src/text.cc
@@ -140,12 +140,12 @@ text_renderer::upload()
     /* Exact-fit is pretty lousy as a growth strategy, but oh well */
     if (verts.size() > bo_capacity) {
         glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(text_vertex), &verts[0], GL_STREAM_DRAW);
-        bo_capacity = verts.size();
-        bo_vertex_count = verts.size();
+        bo_capacity = (GLuint)verts.size();
+        bo_vertex_count = (GLuint)verts.size();
     }
     else {
         glBufferSubData(GL_ARRAY_BUFFER, 0, verts.size() * sizeof(text_vertex), &verts[0]);
-        bo_vertex_count = verts.size();
+        bo_vertex_count = (GLuint)verts.size();
     }
 }
 

--- a/src/wiring.cc
+++ b/src/wiring.cc
@@ -85,6 +85,46 @@ draw_segments(ship_space *ship, frame_data *frame)
 }
 
 
+bool
+remove_segments_containing(ship_space *ship, unsigned attach) {
+    /* remove all segments that contain attach */
+    auto changed = false;
+
+    for (auto si = ship->wire_segments.begin(); si != ship->wire_segments.end(); ) {
+        if (si->first == attach || si->second == attach) {
+            si = ship->wire_segments.erase(si);
+            changed = true;
+        }
+        else {
+            ++si;
+        }
+    }
+    return changed;
+}
+
+
+bool
+relocate_segments_and_entity_attaches(
+    ship_space *ship, unsigned relocated_to, unsigned moved_from) {
+    /* fixup segments with attaches that were relocated */
+    auto changed = false;
+
+    for (auto si = ship->wire_segments.begin(); si != ship->wire_segments.end(); ++si) {
+        if (si->first == moved_from) {
+            si->first = relocated_to;
+            changed = true;
+        }
+
+        if (si->second == moved_from) {
+            si->second = relocated_to;
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
+
 void
 reduce_segments(ship_space *ship) {
     for (size_t i1 = 0; i1 < ship->wire_segments.size(); ++i1) {

--- a/src/wiring.cc
+++ b/src/wiring.cc
@@ -121,6 +121,14 @@ relocate_segments_and_entity_attaches(
         }
     }
 
+    /* fixup entity attaches that were relocated */
+    for (auto& sea : ship->entity_to_attach_lookup) {
+        auto & sea_attaches = sea.second;
+        if (sea_attaches.erase(moved_from)) {
+            sea_attaches.insert(relocated_to);
+        }
+    }
+
     return changed;
 }
 

--- a/src/wiring.h
+++ b/src/wiring.h
@@ -23,6 +23,13 @@ draw_attachments(ship_space *ship, frame_data *frame);
 void
 draw_segments(ship_space *ship, frame_data *frame);
 
+bool
+remove_segments_containing(ship_space *ship, unsigned attach);
+
+bool
+relocate_segments_and_entity_attaches(
+    ship_space *ship, unsigned relocated_to, unsigned moved_from);
+
 void
 reduce_segments(ship_space *ship);
 


### PR DESCRIPTION
This is rebased on #265

Extracted wiring utility functions
wired up moving, removing, creating attaches on entities
