### PR TITLE
component: slim down physics_component data

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -213,8 +213,6 @@ struct entity
         build_static_physics_rb_mat(&mat, et->phys_shape, &physics_man.rigid(ce));
         /* so that we can get back to the entity from a phys raycast */
         physics_man.rigid(ce)->setUserPointer(this);
-        physics_man.mesh(ce) = et->phys_mesh;
-        physics_man.collision(ce) = et->phys_shape;
 
         surface_man.assign_entity(ce);
         surface_man.block(ce) = p;

--- a/src/component/physics_component.cc
+++ b/src/component/physics_component.cc
@@ -12,8 +12,6 @@ physics_component_manager::create_component_instance_data(unsigned count) {
 
     size_t size = sizeof(c_entity) * count;
     size = sizeof(btRigidBody *) * count + align_size<btRigidBody *>(size);
-    size = sizeof(btTriangleMesh *) * count + align_size<btTriangleMesh *>(size);
-    size = sizeof(btCollisionShape *) * count + align_size<btCollisionShape *>(size);
     size += alignof(c_entity);  // for worst-case misalignment of initial ptr
 
     new_buffer.buffer = malloc(size);
@@ -23,13 +21,9 @@ physics_component_manager::create_component_instance_data(unsigned count) {
 
     new_pool.entity = align_ptr((c_entity *)new_buffer.buffer);
     new_pool.rigid = align_ptr((btRigidBody **)(new_pool.entity + count));
-    new_pool.mesh = align_ptr((btTriangleMesh **)(new_pool.rigid + count));
-    new_pool.collision = align_ptr((btCollisionShape **)(new_pool.mesh + count));
 
     memcpy(new_pool.entity, instance_pool.entity, buffer.num * sizeof(c_entity));
     memcpy(new_pool.rigid, instance_pool.rigid, buffer.num * sizeof(btRigidBody *));
-    memcpy(new_pool.mesh, instance_pool.mesh, buffer.num * sizeof(btTriangleMesh *));
-    memcpy(new_pool.collision, instance_pool.collision, buffer.num * sizeof(btCollisionShape *));
 
     free(buffer.buffer);
     buffer = new_buffer;
@@ -45,8 +39,6 @@ physics_component_manager::destroy_instance(instance i) {
 
     instance_pool.entity[i.index] = instance_pool.entity[last_index];
     instance_pool.rigid[i.index] = instance_pool.rigid[last_index];
-    instance_pool.mesh[i.index] = instance_pool.mesh[last_index];
-    instance_pool.collision[i.index] = instance_pool.collision[last_index];
 
     entity_instance_map[last_entity] = i.index;
     entity_instance_map.erase(current_entity);

--- a/src/component/physics_component.h
+++ b/src/component/physics_component.h
@@ -7,17 +7,11 @@
 // physics component
 // rigid     -- rigid body
 // btRigidBody *
-// mesh      -- static mesh
-// btTriangleMesh *
-// collision -- collision shape
-// btCollisionShape *
 
 struct physics_component_manager : component_manager {
     struct instance_data {
         c_entity *entity;
         btRigidBody **rigid;
-        btTriangleMesh **mesh;
-        btCollisionShape **collision;
     } instance_pool;
 
     void create_component_instance_data(unsigned count) override;
@@ -30,17 +24,5 @@ struct physics_component_manager : component_manager {
         auto inst = lookup(e);
 
         return instance_pool.rigid[inst.index];
-    }
-
-    btTriangleMesh *& mesh(c_entity const &e) {
-        auto inst = lookup(e);
-
-        return instance_pool.mesh[inst.index];
-    }
-
-    btCollisionShape *& collision(c_entity const &e) {
-        auto inst = lookup(e);
-
-        return instance_pool.collision[inst.index];
     }
 };


### PR DESCRIPTION
We never actually used this, we just paid to move it around.
It didn't really make sense to store this per-entity anyway -- the physics
mesh itself isn't owned by the entity.

If we /do/ need entity-owned physics meshes, we'll add those later in a
new component (which will be quite a lot rarer)

Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>