### PR TITLE
wiring: split read and write buffers, to avoid ordering anomalies

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1552,6 +1552,8 @@ update()
         tick_power_consumers(ship);
         tick_light_components(ship);
 
+        propagate_comms_wires(ship);
+
         /* HACK: dirty this every frame for now while debugging atmo */
         if (1 || pl.ui_dirty) {
             text->reset();

--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -123,7 +123,7 @@ tick_light_components(ship_space* ship) {
             visited_wires.insert(wire_index);
 
             /* now that we have the wire, see if it has any msgs for us */
-            for (auto msg : wire.msg_buffer) {
+            for (auto msg : wire.read_buffer) {
                 if (msg.desc == comms_msg_type_switch_state) {
                     switchable_man.enabled(ce) = msg.data > 0;
 
@@ -133,11 +133,6 @@ tick_light_components(ship_space* ship) {
                 }
             }
         }
-    }
-
-    for (auto & wires : ship->comms_wires) {
-        auto & wire = wires.second;
-        wire.msg_buffer.clear();
     }
 }
 

--- a/src/wiring/wiring.cc
+++ b/src/wiring/wiring.cc
@@ -296,6 +296,20 @@ calculate_comms_wires(ship_space* ship) {
 
 }
 
+/* Phase boundary: this frame's written messages become the next frame's messages to read.
+ * start off the next frame's written messages as empty.
+ *
+ * This allows any tick code to read or write messages however it likes, but never step on each
+ * other or introduce strange order-based inconsistencies.
+ */
+void
+propagate_comms_wires(ship_space *ship) {
+    for (auto & w : ship->comms_wires) {
+        std::swap(w.second.read_buffer, w.second.write_buffer);
+        w.second.write_buffer.clear();
+    }
+}
+
 void
 publish_message(ship_space* ship, unsigned wire_id, comms_msg msg) {
     if (ship->comms_wires.find(wire_id) == ship->comms_wires.end()) {
@@ -303,5 +317,5 @@ publish_message(ship_space* ship, unsigned wire_id, comms_msg msg) {
     }
 
     auto & wire = ship->comms_wires[wire_id];
-    wire.msg_buffer.push_back(msg);
+    wire.write_buffer.push_back(msg);
 }

--- a/src/wiring/wiring.h
+++ b/src/wiring/wiring.h
@@ -57,4 +57,7 @@ void
 calculate_comms_wires(ship_space *ship);
 
 void
+propagate_comms_wires(ship_space *ship);
+
+void
 publish_message(ship_space *ship, unsigned wire_id, comms_msg msg);

--- a/src/wiring/wiring_data.h
+++ b/src/wiring/wiring_data.h
@@ -26,7 +26,7 @@ struct comms_msg {
 
 
 struct comms_wiring_data {
-    std::vector<comms_msg> msg_buffer;
+    std::vector<comms_msg> read_buffer, write_buffer;
     unsigned num_connected;
 };
 


### PR DESCRIPTION
See comment in source for more details.

Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>