### PR TITLE
Pressure sensor

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -202,6 +202,7 @@ entity_type entity_types[] = {
     { "Switch", "mesh/panel_1x1.obj", 9, true },
     { "Door", "mesh/single_door_frame.obj", 2, false },
     { "Plaidnicator", "mesh/frobnicator.obj", 13, false },
+    { "Pressure Sensor", "mesh/panel_1x1.obj", 12, true },
 };
 
 
@@ -289,6 +290,11 @@ struct entity
             power_provider_man.assign_entity(ce);
             power_provider_man.max_provided(ce) = 12;
             power_provider_man.provided(ce) = 12;
+        }
+        // pressure sensor
+        else if (type == 6) {
+            pressure_man.assign_entity(ce);
+            pressure_man.pressure(ce) = 0.f;
         }
     }
 };
@@ -695,27 +701,18 @@ resize(int width, int height)
 void
 destroy_entity(entity *e)
 {
-    pos_man.destroy_entity_instance(e->ce);
-
-    render_man.destroy_entity_instance(e->ce);
-
+    gas_man.destroy_entity_instance(e->ce);
+    light_man.destroy_entity_instance(e->ce);
     teardown_static_physics_setup(nullptr, nullptr, &physics_man.rigid(e->ce));
     physics_man.destroy_entity_instance(e->ce);
-
+    pos_man.destroy_entity_instance(e->ce);
     power_man.destroy_entity_instance(e->ce);
-
     power_provider_man.destroy_entity_instance(e->ce);
-
-    gas_man.destroy_entity_instance(e->ce);
-
-    light_man.destroy_entity_instance(e->ce);
-
+    pressure_man.destroy_entity_instance(e->ce);
+    render_man.destroy_entity_instance(e->ce);
     surface_man.destroy_entity_instance(e->ce);
-
     switch_man.destroy_entity_instance(e->ce);
-
     switchable_man.destroy_entity_instance(e->ce);
-
     type_man.destroy_entity_instance(e->ce);
 
     for (auto _type = 0; _type < num_wire_types; _type++) {

--- a/main.cc
+++ b/main.cc
@@ -1548,6 +1548,7 @@ update()
         tick_gas_producers(ship);
         tick_power_consumers(ship);
         tick_light_components(ship);
+        tick_pressure_sensors(ship);
 
         calculate_power_wires(ship);
         propagate_comms_wires(ship);

--- a/nightmare.vcxproj
+++ b/nightmare.vcxproj
@@ -230,6 +230,7 @@
     <ClCompile Include="src\component\physics_component.cc" />
     <ClCompile Include="src\component\power_component.cc" />
     <ClCompile Include="src\component\power_provider_component.cc" />
+    <ClCompile Include="src\component\pressure_sensor_component.cc" />
     <ClCompile Include="src\component\relative_position_component.cc" />
     <ClCompile Include="src\component\renderable_component.cc" />
     <ClCompile Include="src\component\surface_attachment_component.cc" />
@@ -269,6 +270,7 @@
     <ClInclude Include="src\component\physics_component.h" />
     <ClInclude Include="src\component\power_component.h" />
     <ClInclude Include="src\component\power_provider_component.h" />
+    <ClInclude Include="src\component\pressure_sensor_component.h" />
     <ClInclude Include="src\component\relative_position_component.h" />
     <ClInclude Include="src\component\renderable_component.h" />
     <ClInclude Include="src\component\surface_attachment_component.h" />

--- a/nightmare.vcxproj.filters
+++ b/nightmare.vcxproj.filters
@@ -144,6 +144,9 @@
     <ClCompile Include="src\component\power_provider_component.cc">
       <Filter>Source Files\component</Filter>
     </ClCompile>
+    <ClCompile Include="src\component\pressure_sensor_component.cc">
+      <Filter>Source Files\component</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\blob.h">
@@ -268,6 +271,9 @@
     </ClInclude>
     <ClInclude Include="src\tools\tools.h">
       <Filter>Header Files\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="src\component\pressure_sensor_component.h">
+      <Filter>Header Files\component</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -19,6 +19,7 @@ extern void mark_lightfield_update(glm::ivec3 center);
 
 /* I have no clue how we're going to actually handle these */
 const char * comms_msg_type_switch_state = "switch_state";
+const char * comms_msg_type_pressure_sensor_state = "pressure_sensor_state";
 
 
 void
@@ -124,8 +125,9 @@ tick_light_components(ship_space* ship) {
             /* now that we have the wire, see if it has any msgs for us */
             /* todo: origin discrimination */
             for (auto msg : wire.read_buffer) {
-                if (msg.desc == comms_msg_type_switch_state) {
-                    switchable_man.enabled(ce) = msg.data > 0;
+                if (msg.desc == comms_msg_type_switch_state ||
+                    msg.desc == comms_msg_type_pressure_sensor_state) {
+
                     auto data = clamp(msg.data, 0.f, 1.f);
                     light_man.intensity(ce) = data;
                     switchable_man.enabled(ce) = data > 0;
@@ -139,6 +141,49 @@ tick_light_components(ship_space* ship) {
     }
 }
 
+void tick_pressure_sensors(ship_space* ship) {
+    for (auto i = 0u; i < pressure_man.buffer.num; i++) {
+        auto ce = pressure_man.instance_pool.entity[i];
+        auto type = wire_type_comms;
+
+        /* all pressure sensors currently require: position */
+        assert(pos_man.exists(ce) || !"pressure sensors must have a position");
+
+        auto pos = pos_man.position(ce);
+
+        glm::ivec3 pos_block = get_coord_containing(pos);
+
+        topo_info *t = topo_find(ship->get_topo_info(pos_block));
+        topo_info *outside = topo_find(&ship->outside_topo_info);
+        zone_info *z = ship->get_zone_info(t);
+        float pressure = z ? (z->air_amount / t->size) : 0.0f;
+
+        auto wire_type = wire_type_comms;
+        auto & comms_attaches = ship->entity_to_attach_lookups[wire_type];
+
+        if (comms_attaches.find(ce) == comms_attaches.end()) {
+            return;
+        }
+
+        std::unordered_set<unsigned> visited_wires;
+        auto const & attaches = comms_attaches[ce];
+        for (auto const & sea : attaches) {
+            auto const & attach = ship->wire_attachments[wire_type][sea];
+            auto wire_index = attach_topo_find(ship, wire_type, attach.parent);
+            if (visited_wires.find(wire_index) != visited_wires.end()) {
+                continue;
+            }
+
+            visited_wires.insert(wire_index);
+
+            comms_msg msg;
+            msg.originator = ce;
+            msg.desc = comms_msg_type_pressure_sensor_state;
+            msg.data = pressure;
+            publish_message(ship, wire_index, msg);
+        }
+    }
+}
 
 void
 draw_renderables(frame_data *frame)

--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -100,7 +100,7 @@ tick_light_components(ship_space* ship) {
         auto ce = light_man.instance_pool.entity[i];
         auto type = wire_type_comms;
 
-        /* all lights currently require: power, position */
+        /* all lights currently require: switchable, position */
         assert(switchable_man.exists(ce) || !"lights must be switchable");
         assert(pos_man.exists(ce) || !"lights must have a position");
 
@@ -122,9 +122,13 @@ tick_light_components(ship_space* ship) {
             visited_wires.insert(wire_index);
 
             /* now that we have the wire, see if it has any msgs for us */
+            /* todo: origin discrimination */
             for (auto msg : wire.read_buffer) {
                 if (msg.desc == comms_msg_type_switch_state) {
                     switchable_man.enabled(ce) = msg.data > 0;
+                    auto data = clamp(msg.data, 0.f, 1.f);
+                    light_man.intensity(ce) = data;
+                    switchable_man.enabled(ce) = data > 0;
 
                     auto pos = pos_man.position(ce);
                     auto block_pos = get_coord_containing(pos);

--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -6,6 +6,7 @@ physics_component_manager physics_man;
 relative_position_component_manager pos_man;
 power_component_manager power_man;
 power_provider_component_manager power_provider_man;
+pressure_sensor_component_manager pressure_man;
 renderable_component_manager render_man;
 surface_attachment_component_manager surface_man;
 switch_component_manager switch_man;

--- a/src/component/component_system_manager.h
+++ b/src/component/component_system_manager.h
@@ -32,6 +32,8 @@ extern switchable_component_manager switchable_man;
 extern type_component_manager type_man;
 
 extern const char * comms_msg_type_switch_state;
+extern const char * comms_msg_type_pressure_sensor_state;
+
 
 void
 tick_gas_producers(ship_space * ship);
@@ -41,6 +43,9 @@ tick_power_consumers(ship_space * ship);
 
 void
 tick_light_components(ship_space * ship);
+
+void
+tick_pressure_sensors(ship_space * ship);
 
 void
 draw_renderables(frame_data *frame);

--- a/src/component/component_system_manager.h
+++ b/src/component/component_system_manager.h
@@ -10,6 +10,7 @@
 #include "physics_component.h"
 #include "power_component.h"
 #include "power_provider_component.h"
+#include "pressure_sensor_component.h"
 #include "relative_position_component.h"
 #include "renderable_component.h"
 #include "surface_attachment_component.h"
@@ -23,6 +24,7 @@ extern physics_component_manager physics_man;
 extern relative_position_component_manager pos_man;
 extern power_component_manager power_man;
 extern power_provider_component_manager power_provider_man;
+extern pressure_sensor_component_manager pressure_man;
 extern renderable_component_manager render_man;
 extern surface_attachment_component_manager surface_man;
 extern switch_component_manager switch_man;

--- a/src/component/pressure_sensor_component.cc
+++ b/src/component/pressure_sensor_component.cc
@@ -1,0 +1,59 @@
+#include <algorithm>
+#include "../memory.h"
+#include "pressure_sensor_component.h"
+
+void
+pressure_sensor_component_manager::create_component_instance_data(unsigned count) {
+    if (count <= buffer.allocated)
+        return;
+
+    component_buffer new_buffer;
+    instance_data new_pool;
+
+    size_t size = sizeof(c_entity) * count;
+    size = sizeof(float) * count + align_size<float>(size);
+    size += alignof(c_entity);  // for worst-case misalignment of initial ptr
+
+    new_buffer.buffer = malloc(size);
+    new_buffer.num = buffer.num;
+    new_buffer.allocated = count;
+    memset(new_buffer.buffer, 0, size);
+
+    new_pool.entity = align_ptr((c_entity *)new_buffer.buffer);
+    new_pool.pressure = align_ptr((float *)(new_pool.entity + count));
+
+    memcpy(new_pool.entity, instance_pool.entity, buffer.num * sizeof(c_entity));
+    memcpy(new_pool.pressure, instance_pool.pressure, buffer.num * sizeof(float));
+
+    free(buffer.buffer);
+    buffer = new_buffer;
+
+    instance_pool = new_pool;
+}
+
+void
+pressure_sensor_component_manager::destroy_instance(instance i) {
+    auto last_index = buffer.num - 1;
+    auto last_entity = instance_pool.entity[last_index];
+    auto current_entity = instance_pool.entity[i.index];
+
+    instance_pool.entity[i.index] = instance_pool.entity[last_index];
+    instance_pool.pressure[i.index] = instance_pool.pressure[last_index];
+
+    entity_instance_map[last_entity] = i.index;
+    entity_instance_map.erase(current_entity);
+
+    --buffer.num;
+}
+
+void
+pressure_sensor_component_manager::entity(const c_entity& e) {
+    if (buffer.num >= buffer.allocated) {
+        printf("Increasing size of switch buffer. Please adjust\n");
+        create_component_instance_data(std::max(1u, buffer.allocated) * 2);
+    }
+
+    auto inst = lookup(e);
+
+    instance_pool.entity[inst.index] = e;
+}

--- a/src/component/pressure_sensor_component.h
+++ b/src/component/pressure_sensor_component.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "component_manager.h"
+
+// switch component
+// pressure -- atmo pressure. 0-1
+// float
+
+struct pressure_sensor_component_manager : component_manager {
+    struct instance_data {
+        c_entity *entity;
+        float *pressure;
+    } instance_pool;
+
+    void create_component_instance_data(unsigned count) override;
+
+    void destroy_instance(instance i) override;
+
+    void entity(c_entity const &e) override;
+
+    float & pressure(c_entity const &e) {
+        auto inst = lookup(e);
+
+        return instance_pool.pressure[inst.index];
+    }
+};


### PR DESCRIPTION
light supports scalar values
pressure sensor spits out on wire

For great entertainment, in airtight room hook light up to power, comms to sensor. Add a few frobnicators (currently one frob uses one plaid power). Use frobnicators to turn on. Observe as light slowly increases in brightness.