### PR TITLE
wiring: fix powered state bug

### DIFF
--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -111,7 +111,7 @@ tick_power_consumers(ship_space * ship) {
 
             visited_wires.insert(wire_index);
             /* todo: this needs to somehow handle multiple wires */
-            powered |= wire.total_power >= wire.total_draw;
+            powered |= wire.total_power >= wire.total_draw && wire.total_power > 0;
         }
 
         if (powered != old_powered) {


### PR DESCRIPTION
This fixes an issue where we'd get one frame of powered state when attaching a wire with 0 power (or just a single power wire attach, same thing basically) to a power consumer.