### PR TITLE
main/tools: Support entities multiple blocks tall

### DIFF
--- a/src/tools/remove_block.cc
+++ b/src/tools/remove_block.cc
@@ -37,11 +37,12 @@ struct remove_block_tool : tool
         /* if there was a block entity here, find and remove it. block
          * ents are "attached" to the zm surface */
         if (bl->type == block_entity) {
+            /* TODO: should this even allow entity removal? This may be nothing more than
+             * historical accident.
+             */
             remove_ents_from_surface(rc->bl, surface_zm);
-
-            for (int face = 0; face < face_count; face++) {
-                bl->surf_space[face] = 0;   /* we've just thrown away the block ent */
-            }
+            mark_lightfield_update(rc->bl);
+            return;
         }
 
         /* block removal */


### PR DESCRIPTION
Fixes #318.

This is still a /little/ hackish in that I think we'd prefer to
support multiple surface components for entities that are doing this,
or rework the entity/block-system code completely.

Allows block entities to be more than one block tall, as the door is.

Get rid of some spurious chunk rebuilds when doing entity-only work.

Move some more logic into destroy_entity that was previously spread
everywhere.

Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>