### PR TITLE
Simple reader use

### DIFF
--- a/gen/light
+++ b/gen/light
@@ -1,3 +1,2 @@
 float,intensity
 float,requested_intensity
-unsigned,type

--- a/main.cc
+++ b/main.cc
@@ -269,6 +269,13 @@ struct entity
             *door.mesh = door_hw;
             *door.pos = 1.0f;
             *door.desired_pos = 1.0f;
+
+            reader_man.assign_entity(ce);
+            auto reader = reader_man.get_instance_data(ce);
+            *reader.name = "desired state";
+            reader.source->id = 0;
+            *reader.desc = nullptr;
+            *reader.data = 1.0f;
         }
         // frobnicator
         else if (type == 1) {

--- a/main.cc
+++ b/main.cc
@@ -297,6 +297,13 @@ struct entity
             *light.intensity = 1.0f;
             *light.requested_intensity = 1.0f;
             *light.type = 1;
+
+            reader_man.assign_entity(ce);
+            auto reader = reader_man.get_instance_data(ce);
+            *reader.name = "light brightness";
+            reader.source->id = 0;
+            *reader.desc = nullptr;
+            *reader.data = 1.0f;
         }
         // warning light
         else if (type == 3) {
@@ -311,6 +318,13 @@ struct entity
             *light.intensity = 1.0f;
             *light.requested_intensity = 1.0f;
             *light.type = 2;
+
+            reader_man.assign_entity(ce);
+            auto reader = reader_man.get_instance_data(ce);
+            *reader.name = "light brightness";
+            reader.source->id = 0;
+            *reader.desc = comms_msg_type_sensor_comparison_state;      // temp until we have discriminator tool
+            *reader.data = 1.0f;
         }
         // display panel
         else if (type == 4) {
@@ -325,6 +339,13 @@ struct entity
             *light.intensity = 0.15f;
             *light.requested_intensity = 0.15f;
             *light.type = 0;
+
+            reader_man.assign_entity(ce);
+            auto reader = reader_man.get_instance_data(ce);
+            *reader.name = "light brightness";
+            reader.source->id = 0;
+            *reader.desc = nullptr;
+            *reader.data = 0.15f;
         }
         // switch
         else if (type == 5) {

--- a/main.cc
+++ b/main.cc
@@ -296,7 +296,6 @@ struct entity
             auto light = light_man.get_instance_data(ce);
             *light.intensity = 1.0f;
             *light.requested_intensity = 1.0f;
-            *light.type = 1;
 
             reader_man.assign_entity(ce);
             auto reader = reader_man.get_instance_data(ce);
@@ -317,7 +316,6 @@ struct entity
             auto light = light_man.get_instance_data(ce);
             *light.intensity = 1.0f;
             *light.requested_intensity = 1.0f;
-            *light.type = 2;
 
             reader_man.assign_entity(ce);
             auto reader = reader_man.get_instance_data(ce);
@@ -338,7 +336,6 @@ struct entity
             auto light = light_man.get_instance_data(ce);
             *light.intensity = 0.15f;
             *light.requested_intensity = 0.15f;
-            *light.type = 0;
 
             reader_man.assign_entity(ce);
             auto reader = reader_man.get_instance_data(ce);

--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -235,7 +235,6 @@ tick_power_consumers(ship_space *ship) {
         auto ce = power_man.instance_pool.entity[i];
 
         auto & powered = power_man.instance_pool.powered[i];
-        auto old_powered = powered;
         powered = false;
 
         auto & power_attaches = ship->entity_to_attach_lookups[wire_type_power];
@@ -257,15 +256,6 @@ tick_power_consumers(ship_space *ship) {
             /* todo: this needs to somehow handle multiple wires */
             if (wire.total_power >= wire.total_draw && wire.total_power > 0) {
                 powered = true;
-            }
-        }
-
-        if (powered != old_powered) {
-            /* if a light changed power state, do the required update now */
-            if (light_man.exists(ce)) {
-                auto pos = *pos_man.get_instance_data(ce).position;
-                auto block_pos = get_coord_containing(pos);
-                mark_lightfield_update(block_pos);
             }
         }
     }

--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -234,8 +234,7 @@ tick_power_consumers(ship_space *ship) {
     for (auto i = 0u; i < power_man.buffer.num; i++) {
         auto ce = power_man.instance_pool.entity[i];
 
-        auto & powered = power_man.instance_pool.powered[i];
-        powered = false;
+        power_man.instance_pool.powered[i] = false;
 
         auto & power_attaches = ship->entity_to_attach_lookups[wire_type_power];
         auto attaches = power_attaches.find(ce);
@@ -243,19 +242,13 @@ tick_power_consumers(ship_space *ship) {
             continue;
         }
 
-        std::unordered_set<unsigned> visited_wires;
         for (auto sea : attaches->second) {
             auto wire_index = attach_topo_find(ship, wire_type_power, sea);
-            if (visited_wires.find(wire_index) != visited_wires.end()) {
-                continue;
-            }
 
             auto const & wire = ship->power_wires[wire_index];
 
-            visited_wires.insert(wire_index);
-            /* todo: this needs to somehow handle multiple wires */
             if (wire.total_power >= wire.total_draw && wire.total_power > 0) {
-                powered = true;
+                power_man.instance_pool.powered[i] = true;
             }
         }
     }

--- a/src/component/light_component.cc
+++ b/src/component/light_component.cc
@@ -16,7 +16,6 @@ light_component_manager::create_component_instance_data(unsigned count) {
     size_t size = sizeof(c_entity) * count;
     size = sizeof(float) * count + align_size<float>(size);
     size = sizeof(float) * count + align_size<float>(size);
-    size = sizeof(unsigned) * count + align_size<unsigned>(size);
     size += 16;   // for worst-case misalignment of initial ptr
 
     new_buffer.buffer = malloc(size);
@@ -27,12 +26,10 @@ light_component_manager::create_component_instance_data(unsigned count) {
     new_pool.entity = align_ptr((c_entity *)new_buffer.buffer);
     new_pool.intensity = align_ptr((float *)(new_pool.entity + count));
     new_pool.requested_intensity = align_ptr((float *)(new_pool.intensity + count));
-    new_pool.type = align_ptr((unsigned *)(new_pool.requested_intensity + count));
 
     memcpy(new_pool.entity, instance_pool.entity, buffer.num * sizeof(c_entity));
     memcpy(new_pool.intensity, instance_pool.intensity, buffer.num * sizeof(float));
     memcpy(new_pool.requested_intensity, instance_pool.requested_intensity, buffer.num * sizeof(float));
-    memcpy(new_pool.type, instance_pool.type, buffer.num * sizeof(unsigned));
 
     free(buffer.buffer);
     buffer = new_buffer;
@@ -49,7 +46,6 @@ light_component_manager::destroy_instance(instance i) {
     instance_pool.entity[i.index] = instance_pool.entity[last_index];
     instance_pool.intensity[i.index] = instance_pool.intensity[last_index];
     instance_pool.requested_intensity[i.index] = instance_pool.requested_intensity[last_index];
-    instance_pool.type[i.index] = instance_pool.type[last_index];
 
     entity_instance_map[last_entity] = i.index;
     entity_instance_map.erase(current_entity);

--- a/src/component/light_component.h
+++ b/src/component/light_component.h
@@ -9,7 +9,6 @@ struct light_component_manager : component_manager {
         c_entity *entity;
         float *intensity;
         float *requested_intensity;
-        unsigned *type;
     } instance_pool;
 
     void create_component_instance_data(unsigned count) override;
@@ -23,7 +22,6 @@ struct light_component_manager : component_manager {
         d.entity = instance_pool.entity + inst.index;
         d.intensity = instance_pool.intensity + inst.index;
         d.requested_intensity = instance_pool.requested_intensity + inst.index;
-        d.type = instance_pool.type + inst.index;
 
         return d;
     }


### PR DESCRIPTION
This updates the light component to use reader_component for its wire IO, and takes advantage of various simplifications that can now be made.

Note that all lights reevaluate their intensity based on reader state every tick now -- so tick_power_consumers doesn't need a special case.