### PR TITLE
render: Let the tool determine whether or not to preview

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1296,6 +1296,9 @@ struct add_wiring_tool : tool
     }
 
     void preview(raycast_info *rc, frame_data *frame) override {
+        if (!rc->hit)
+            return;
+
         /* do a real, generic raycast */
 
         /* TODO: Move the assignment logic into the wiring system */
@@ -2096,9 +2099,7 @@ struct play_state : game_state {
         ship->raycast(pl.eye, pl.dir, &rc);
 
         /* tool preview */
-        if (rc.hit) {
-            t->preview(&rc, frame);
-        }
+        t->preview(&rc, frame);
     }
 
     void set_slot(unsigned slot) {


### PR DESCRIPTION
Most of the tools are already doing this in their can_use() helper. The only one
I found which isn't is the wiring tool. This will be needed for the ghetto
flashlight whose distance is limited by the tool itself.

Signed-off-by: Ben Widawsky <ben@bwidawsk.net>