### PR TITLE
phys: change user ptr type from entity to phys_ent_ref

### DIFF
--- a/src/char.cc
+++ b/src/char.cc
@@ -861,7 +861,7 @@ void en_char_controller::stand(btCollisionWorld *collisionWorld)
 
 
 /* Not part of CC, but reuses the same callbacks etc. */
-entity *
+phys_ent_ref *
 phys_raycast(glm::vec3 start, glm::vec3 end, btCollisionObject *ignore, btCollisionWorld *world)
 {
     btVector3 start_bt = glm_to_bt(start);
@@ -870,7 +870,7 @@ phys_raycast(glm::vec3 start, glm::vec3 end, btCollisionObject *ignore, btCollis
     world->rayTest(start_bt, end_bt, callback);
 
     if (callback.hasHit()) {
-        return (entity *)callback.m_collisionObject->getUserPointer();
+        return (phys_ent_ref *)callback.m_collisionObject->getUserPointer();
     }
 
     return nullptr;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -3,12 +3,11 @@
 #include "block.h"
 #include "fixed_cube.h"
 #include "mesh.h"
+#include "component/c_entity.h"
 
 #include <vector>
 
 #define CHUNK_SIZE 8
-
-struct entity;
 
 class btTriangleMesh;
 class btCollisionShape;
@@ -43,7 +42,7 @@ struct chunk {
     struct render_chunk render_chunk;
 
     /* entities */
-    std::vector<entity *> entities;
+    std::vector<c_entity> entities;
 
     void prepare_render(int x, int y, int z);
 };

--- a/src/physics.h
+++ b/src/physics.h
@@ -4,6 +4,7 @@
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include <glm/glm.hpp>
 #include "char.h"
+#include "component/c_entity.h"
 
 
 /* in player.h */
@@ -53,6 +54,12 @@ struct generic_raycast_info {
     glm::vec3 fromHit;
 };
 
+/* Identifies an entity and a mesh/meshpart, to be referenced by the physics system. */
+struct phys_ent_ref
+{
+    c_entity ce;
+};
+
 
 void
 build_static_physics_rb(int x, int y, int z, btCollisionShape *shape, btRigidBody **rb);
@@ -69,9 +76,7 @@ void
 teardown_static_physics_setup(btTriangleMesh **mesh, btCollisionShape **shape, btRigidBody **rb);
 
 
-struct entity;
-
-entity *
+phys_ent_ref *
 phys_raycast(glm::vec3 start, glm::vec3 end,
              btCollisionObject *ignore, btCollisionWorld *world);
 


### PR DESCRIPTION
This is one of the few remaining things before we can kill entity. It also
provides the path forward to having submeshes identifiable via raycast.

Signed-off-by: Chris Forbes <chrisf@ijw.co.nz>