### PR TITLE
tools: don't allow door magic surfaces to be ripped out

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -853,6 +853,11 @@ destroy_entity(c_entity e)
         }
     }
 
+    if (door_man.exists(e)) {
+        /* make sure the door is /open/ -- no magic surfaces left lying around. */
+        set_door_state(ship, e, surface_none);
+    }
+
     if (physics_man.exists(e)) {
         auto phys_data = physics_man.get_instance_data(e);
         phys_ent_ref *per = (phys_ent_ref *)(*phys_data.rigid)->getUserPointer();

--- a/main.cc
+++ b/main.cc
@@ -1029,7 +1029,8 @@ struct add_surface_entity_tool : tool
 
         int index = normal_to_surface_index(rc);
 
-        if (bl->surfs[index] == surface_none)
+        if (bl->surfs[index] == surface_none ||
+            bl->surfs[index] == surface_door)
             return false;
 
         block *other_side = ship->get_block(rc->p);

--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -134,12 +134,9 @@ set_door_state(ship_space *ship, relative_position_component_manager::instance_d
         auto ym = glm::ivec3(pos.x, pos.y - 1, pos.z);
         auto yp = glm::ivec3(pos.x, pos.y + 1, pos.z);
 
-        auto chunk = ship->get_chunk_containing(pos);
-        chunk->render_chunk.valid = false;
-        chunk = ship->get_chunk_containing(ym);
-        chunk->render_chunk.valid = false;
-        chunk = ship->get_chunk_containing(yp);
-        chunk->render_chunk.valid = false;
+        ship->get_chunk_containing(pos)->render_chunk.valid = false;
+        ship->get_chunk_containing(ym)->render_chunk.valid = false;
+        ship->get_chunk_containing(yp)->render_chunk.valid = false;
 
         /* we'll be calling ensure in set/remove surfaces anyway */
         auto bl = ship->ensure_block(pos);

--- a/src/component/component_system_manager.cc
+++ b/src/component/component_system_manager.cc
@@ -125,8 +125,9 @@ tick_gas_producers(ship_space *ship)
 }
 
 void
-set_door_state(ship_space *ship, relative_position_component_manager::instance_data position, surface_type s)
+set_door_state(ship_space *ship, c_entity ce, surface_type s)
 {
+    auto position = pos_man.get_instance_data(ce);
     auto pos = glm::ivec3(*position.position);
 
     /* todo: this has no support for rotation whatsoever */
@@ -179,7 +180,6 @@ tick_doors(ship_space *ship)
         assert(reader_man.exists(ce) || !"doors must have reader");
 
         auto power = power_man.get_instance_data(ce);
-        auto position = pos_man.get_instance_data(ce);
         auto reader = reader_man.get_instance_data(ce);
 
         /* it's a power door, it's not going /anywhere/ without power */
@@ -199,7 +199,7 @@ tick_doors(ship_space *ship)
 
         /* did we just enter desired state? */
         if (desired_state == door_man.instance_pool.pos[i] && !in_desired_state) {
-            set_door_state(ship, position, desired_state ? surface_none : surface_door);
+            set_door_state(ship, ce, desired_state ? surface_none : surface_door);
         }
     }
 }

--- a/src/component/component_system_manager.h
+++ b/src/component/component_system_manager.h
@@ -74,3 +74,6 @@ draw_renderables(frame_data *frame);
 
 void
 draw_doors(frame_data *frame);
+
+void
+set_door_state(ship_space *ship, c_entity ce, surface_type s);

--- a/src/tools/remove_block.cc
+++ b/src/tools/remove_block.cc
@@ -47,7 +47,7 @@ struct remove_block_tool : tool
 
         /* strip any orphaned surfaces */
         for (int index = 0; index < 6; index++) {
-            if (bl->surfs[index]) {
+            if (bl->surfs[index] != surface_none && bl->surfs[index] != surface_door) {
 
                 auto s = surface_index_to_normal(index);
 

--- a/src/tools/remove_surface.cc
+++ b/src/tools/remove_surface.cc
@@ -28,7 +28,7 @@ struct remove_surface_tool : tool
 
         block *bl = rc->block;
         int index = normal_to_surface_index(rc);
-        return bl && bl->surfs[index] != surface_none;
+        return bl && bl->surfs[index] != surface_none && bl->surfs[index] != surface_door;
     }
 
     void use(raycast_info *rc) override


### PR DESCRIPTION
Fix all the weird interactions between door magic surfaces and everything else.

Fixes #323.