### PR TITLE
Added rotations to block and surface entities.

### DIFF
--- a/gen/relative_position
+++ b/gen/relative_position
@@ -1,2 +1,3 @@
 glm::vec3,position
 glm::mat4,mat
+float,rotation

--- a/src/component/relative_position_component.cc
+++ b/src/component/relative_position_component.cc
@@ -16,6 +16,7 @@ relative_position_component_manager::create_component_instance_data(unsigned cou
     size_t size = sizeof(c_entity) * count;
     size = sizeof(glm::vec3) * count + align_size<glm::vec3>(size);
     size = sizeof(glm::mat4) * count + align_size<glm::mat4>(size);
+    size = sizeof(float) * count + align_size<float>(size);
     size += 16;   // for worst-case misalignment of initial ptr
 
     new_buffer.buffer = malloc(size);
@@ -26,10 +27,12 @@ relative_position_component_manager::create_component_instance_data(unsigned cou
     new_pool.entity = align_ptr((c_entity *)new_buffer.buffer);
     new_pool.position = align_ptr((glm::vec3 *)(new_pool.entity + count));
     new_pool.mat = align_ptr((glm::mat4 *)(new_pool.position + count));
+    new_pool.rotation = align_ptr((float *)(new_pool.mat + count));
 
     memcpy(new_pool.entity, instance_pool.entity, buffer.num * sizeof(c_entity));
     memcpy(new_pool.position, instance_pool.position, buffer.num * sizeof(glm::vec3));
     memcpy(new_pool.mat, instance_pool.mat, buffer.num * sizeof(glm::mat4));
+    memcpy(new_pool.rotation, instance_pool.rotation, buffer.num * sizeof(float));
 
     free(buffer.buffer);
     buffer = new_buffer;
@@ -46,6 +49,7 @@ relative_position_component_manager::destroy_instance(instance i) {
     instance_pool.entity[i.index] = instance_pool.entity[last_index];
     instance_pool.position[i.index] = instance_pool.position[last_index];
     instance_pool.mat[i.index] = instance_pool.mat[last_index];
+    instance_pool.rotation[i.index] = instance_pool.rotation[last_index];
 
     entity_instance_map[last_entity] = i.index;
     entity_instance_map.erase(current_entity);

--- a/src/component/relative_position_component.h
+++ b/src/component/relative_position_component.h
@@ -9,6 +9,7 @@ struct relative_position_component_manager : component_manager {
         c_entity *entity;
         glm::vec3 *position;
         glm::mat4 *mat;
+        float *rotation;
     } instance_pool;
 
     void create_component_instance_data(unsigned count) override;
@@ -22,6 +23,7 @@ struct relative_position_component_manager : component_manager {
         d.entity = instance_pool.entity + inst.index;
         d.position = instance_pool.position + inst.index;
         d.mat = instance_pool.mat + inst.index;
+        d.rotation = instance_pool.rotation + inst.index;
 
         return d;
     }

--- a/src/server_common.cc
+++ b/src/server_common.cc
@@ -2,6 +2,21 @@
 
 extern hw_mesh *door_hw;
 
+entity_type entity_types[] = {
+    { "Door", "mesh/single_door_frame.dae", 2, false, 2 },
+    { "Frobnicator", "mesh/frobnicator.dae", 3, false, 1 },
+    { "Light", "mesh/panel_4x4.dae", 8, true, 1 },
+    { "Warning Light", "mesh/warning_light.dae", 8, true, 1 },
+    { "Display Panel", "mesh/panel_4x4.dae", 7, true, 1 },
+    { "Switch", "mesh/panel_1x1.dae", 9, true, 1 },
+    { "Plaidnicator", "mesh/frobnicator.dae", 13, false, 1 },
+    { "Pressure Sensor 1", "mesh/panel_1x1.dae", 12, true, 1 },
+    { "Pressure Sensor 2", "mesh/panel_1x1.dae", 14, true, 1 },
+    { "Sensor Comparator", "mesh/panel_1x1.dae", 13, true, 1 },
+    { "Proximity Sensor", "mesh/panel_1x1.dae", 3, true, 1 },
+    { "Flashlight", "mesh/no_place.dae", 3, true, 1 },
+};
+
 void
 remove_ents_from_surface(glm::ivec3 b, int face, physics *phy)
 {
@@ -39,19 +54,26 @@ remove_ents_from_surface(glm::ivec3 b, int face, physics *phy)
 
 
 glm::mat4
-mat_block_face(glm::ivec3 p, int face)
+mat_block_face(glm::ivec3 p, int face, float rotation)
 {
     auto norm = glm::vec3(surface_index_to_normal(face));
     auto pos = glm::vec3(p) + glm::vec3(0.5f) + 0.5f * norm;
-    return mat_rotate_mesh(pos, -norm);
+    return glm::rotate(mat_rotate_mesh(pos, -norm), rotation, glm::vec3(0, 0, 1));
 }
 
 
-c_entity
-spawn_entity(glm::ivec3 p, unsigned type, int face, physics *phy) {
+glm::mat4
+mat_block_face(glm::ivec3 p, int face)
+{
+    return mat_block_face(p, face, 0);
+}
+
+
+c_entity 
+spawn_entity(glm::ivec3 p, unsigned type, int face, physics *phy, float rotation) {
     auto ce = c_entity::spawn();
 
-    auto mat = mat_block_face(p, face);
+    auto mat = mat_block_face(p, face, rotation);
 
     auto et = &entity_types[type];
 
@@ -79,6 +101,7 @@ spawn_entity(glm::ivec3 p, unsigned type, int face, physics *phy) {
     auto pos = pos_man.get_instance_data(ce);
     *pos.position = p;
     *pos.mat = mat;
+    *pos.rotation = rotation;
 
     /* hack to not render a mesh for the flashlight */
     /* todo: handle entities that don't need to be rendered*/
@@ -248,6 +271,12 @@ spawn_entity(glm::ivec3 p, unsigned type, int face, physics *phy) {
     }
 
     return ce;
+}
+
+
+c_entity 
+spawn_entity(glm::ivec3 p, unsigned type, int face, physics *phy) {
+    return spawn_entity(p, type, face, phy, 0);
 }
 
 

--- a/src/server_common.h
+++ b/src/server_common.h
@@ -7,7 +7,9 @@ extern ship_space *ship;
 
 void remove_ents_from_surface(glm::ivec3 b, int face, physics *phy);
 glm::mat4 mat_block_face(glm::ivec3 p, int face);
+glm::mat4 mat_block_face(glm::ivec3 p, int face, float rotation);
 c_entity spawn_entity(glm::ivec3 p, unsigned type, int face, physics *phy);
+c_entity spawn_entity(glm::ivec3 p, unsigned type, int face, physics *phy, float rotation);
 void destroy_entity(c_entity e, physics *phy);
 
 struct entity_type
@@ -27,17 +29,4 @@ struct entity_type
 };
 
 
-static entity_type entity_types[] = {
-    { "Door", "mesh/single_door_frame.dae", 2, false, 2 },
-    { "Frobnicator", "mesh/frobnicator.dae", 3, false, 1 },
-    { "Light", "mesh/panel_4x4.dae", 8, true, 1 },
-    { "Warning Light", "mesh/warning_light.dae", 8, true, 1 },
-    { "Display Panel", "mesh/panel_4x4.dae", 7, true, 1 },
-    { "Switch", "mesh/panel_1x1.dae", 9, true, 1 },
-    { "Plaidnicator", "mesh/frobnicator.dae", 13, false, 1 },
-    { "Pressure Sensor 1", "mesh/panel_1x1.dae", 12, true, 1 },
-    { "Pressure Sensor 2", "mesh/panel_1x1.dae", 14, true, 1 },
-    { "Sensor Comparator", "mesh/panel_1x1.dae", 13, true, 1 },
-    { "Proximity Sensor", "mesh/panel_1x1.dae", 3, true, 1 },
-    { "Flashlight", "mesh/no_place.dae", 3, true, 1 },
-};
+extern entity_type entity_types[12];


### PR DESCRIPTION
Entities can be turned by 90 degree snaps using alt_use
Modified doors to take rotation into account in set_door_state
Fixed entity_types array crash
Fixes #293

![image](https://cloud.githubusercontent.com/assets/14932749/10867229/57e43a88-801c-11e5-85f4-b35640a59ee4.png)
