### PR TITLE
Vertex format change for explicit UV

### DIFF
--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -93,9 +93,13 @@ load_mesh(char const *filename) {
                 // NOTE: we assume that all mesh origins coincide, so we're not applying transforms here
                 auto submesh_base = (unsigned)verts.size();
 
-                for (unsigned int j = 0; j < m->mNumVertices; j++)
+                for (unsigned int j = 0; j < m->mNumVertices; j++) {
                     verts.push_back(vertex(m->mVertices[j].x, m->mVertices[j].y, m->mVertices[j].z,
-                        -m->mNormals[j].x, -m->mNormals[j].y, -m->mNormals[j].z, 0 /* mat */));
+                        -m->mNormals[j].x, -m->mNormals[j].y, -m->mNormals[j].z,
+                        0 /* mat */,
+                        m->mTextureCoords[0] ? m->mTextureCoords[0][j].x : 0.0f,
+                        m->mTextureCoords[0] ? m->mTextureCoords[0][j].y : 0.0f));
+                }
 
                 for (unsigned int j = 0; j < m->mNumFaces; j++) {
                     if (m->mFaces[j].mNumIndices != 3)

--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -167,6 +167,9 @@ upload_mesh(sw_mesh *mesh)
     glEnableVertexAttribArray(2);
     glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(vertex), (GLvoid const *)offsetof(vertex, nx));
 
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(vertex), (GLvoid const *)offsetof(vertex, u));
+
     glGenBuffers(1, &ret->ibo);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ret->ibo);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh->num_indices * sizeof(unsigned), mesh->indices, GL_STATIC_DRAW);

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -26,14 +26,16 @@ struct vertex {
     float nx, ny, nz;
     //uint32_t normal_packed;
     uint32_t mat;
+    float u, v;
 
-    vertex() : x(0), y(0), z(0), mat(0) {}
+    vertex() : x(0), y(0), z(0), mat(0), u(0), v(0) {}
 
-    vertex(float x, float y, float z, float nx, float ny, float nz, int mat)
+    vertex(float x, float y, float z, float nx, float ny, float nz, int mat, float u, float v)
         : x(x), y(y), z(z),
           nx(nx), ny(ny), nz(nz),
           //normal_packed(glm::packSnorm3x10_1x2(glm::vec4(nx, ny, nz, 0))),
-          mat(mat)
+          mat(mat),
+          u(u), v(v)
     {
     }
 };


### PR DESCRIPTION
Not consumed by any shader yet, but this adds the host-side plumbing to make it work.